### PR TITLE
Add Travis-CI for macOS and Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+matrix:
+  include:
+    - os: linux
+      dist: bionic
+    - os: osx
+      osx_image: xcode10.3
+addons:
+  apt:
+    packages:
+      - qt5-default
+      - qt5-qmake
+      - qt5-image-formats-plugins
+  homebrew:
+    packages:
+      - qt
+
+install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew link --force qt ; fi
+script:
+  - qmake
+  - make


### PR DESCRIPTION
This builds qView on macOS and Linux. It should be relatively easy to expand this to deploy to e.g. [GitHub releases](https://docs.travis-ci.com/user/deployment-v2/providers/releases/) (for #234).

Note that you still need to sign in with your GitHub account at https://travis-ci.com/ to enable building.