### PR TITLE
Adding information in fullscreen

### DIFF
--- a/qView.pro
+++ b/qView.pro
@@ -19,7 +19,6 @@ CONFIG -= debug_and_release debug_and_release_target
 
 # enable c++11
 CONFIG += c++11
-CONFIG += static
 
 # Windows specific stuff
 win32:QT += svg # needed for including svg support in static build

--- a/qView.pro
+++ b/qView.pro
@@ -19,6 +19,7 @@ CONFIG -= debug_and_release debug_and_release_target
 
 # enable c++11
 CONFIG += c++11
+CONFIG += static
 
 # Windows specific stuff
 win32:QT += svg # needed for including svg support in static build

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -239,8 +239,8 @@ void MainWindow::settingsUpdated()
     slideshowTimer->setInterval(static_cast<int>(settingsManager.getDouble("slideshowtimer")*1000));
 
     // details in fullscreen
-    auto details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    ui->label->setVisible(details);
+    bool details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
+    ui->imageDetails->setVisible(details);
 
 }
 
@@ -337,10 +337,8 @@ void MainWindow::buildWindowTitle()
 
     setWindowTitle(newString);
     bool details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    if (details and newString.size() != 0) {
-        ui->label->setText(newString);
-    } else {
-        ui->label->setVisible(false);
+    if (details and newString.isEmpty()) {
+        ui->imageDetails->setText(newString);
     }
     windowHandle()->setFilePath(getCurrentFileDetails().fileInfo.absoluteFilePath());
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -239,8 +239,7 @@ void MainWindow::settingsUpdated()
     slideshowTimer->setInterval(static_cast<int>(settingsManager.getDouble("slideshowtimer")*1000));
 
     // details in fullscreen
-    bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    ui->imageDetails->setVisible(showDetails);
+    ui->imageDetails->setVisible(false);
 
 }
 
@@ -336,10 +335,10 @@ void MainWindow::buildWindowTitle()
     }
 
     setWindowTitle(newString);
-    bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    if (showDetails and newString.isEmpty()) {
-        ui->imageDetails->setText(newString);
-    }
+
+    // Update details of image at the top in fullscreen
+    ui->imageDetails->setText(newString);
+
     windowHandle()->setFilePath(getCurrentFileDetails().fileInfo.absoluteFilePath());
 }
 
@@ -801,7 +800,8 @@ void MainWindow::increaseSpeed()
 
 void MainWindow::toggleFullScreen()
 {
-    if (windowState() == Qt::WindowFullScreen)
+    bool isFullscreen = windowState() == Qt::WindowFullScreen;
+    if (isFullscreen)
     {
         setWindowState(storedWindowState);
     }
@@ -810,4 +810,6 @@ void MainWindow::toggleFullScreen()
         storedWindowState = windowState();
         showFullScreen();
     }
+    bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
+    ui->imageDetails->setVisible(showDetails and !isFullscreen);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -47,6 +47,9 @@ MainWindow::MainWindow(QWidget *parent) :
     graphicsView = new QVGraphicsView(this);
     centralWidget()->layout()->addWidget(graphicsView);
 
+    // Hide fullscreen label by default
+    ui->fullscreenLabel->hide();
+
     // Connect graphicsview signals
     connect(graphicsView, &QVGraphicsView::fileLoaded, this, &MainWindow::fileLoaded);
     connect(graphicsView, &QVGraphicsView::updatedLoadedPixmapItem, this, &MainWindow::setWindowSize);
@@ -182,6 +185,9 @@ void MainWindow::changeEvent(QEvent *event)
                 fullscreenAction->setIcon(QIcon::fromTheme("view-fullscreen"));
             }
         }
+
+        if (qvApp->getSettingsManager().getBoolean("fullscreendetails"))
+            ui->fullscreenLabel->setVisible(windowState() == Qt::WindowFullScreen);
     }
 }
 
@@ -238,11 +244,8 @@ void MainWindow::settingsUpdated()
     //slideshow timer
     slideshowTimer->setInterval(static_cast<int>(settingsManager.getDouble("slideshowtimer")*1000));
 
-    // Show details in fullscreen if akready in fullscreen
-    bool isFullscreen = windowState() == Qt::WindowFullScreen;
-    bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    ui->imageDetails->setVisible(showDetails && isFullscreen);
 
+    ui->fullscreenLabel->setVisible(qvApp->getSettingsManager().getBoolean("fullscreendetails") && (windowState() == Qt::WindowFullScreen));
 }
 
 void MainWindow::shortcutsUpdated()
@@ -338,8 +341,8 @@ void MainWindow::buildWindowTitle()
 
     setWindowTitle(newString);
 
-    // Update details of image at the top in fullscreen
-    ui->imageDetails->setText(newString);
+    // Update fullscreen label to titlebar text as well
+    ui->fullscreenLabel->setText(newString);
 
     windowHandle()->setFilePath(getCurrentFileDetails().fileInfo.absoluteFilePath());
 }
@@ -802,8 +805,7 @@ void MainWindow::increaseSpeed()
 
 void MainWindow::toggleFullScreen()
 {
-    bool isFullscreen = windowState() == Qt::WindowFullScreen;
-    if (isFullscreen)
+    if (windowState() == Qt::WindowFullScreen)
     {
         setWindowState(storedWindowState);
     }
@@ -812,6 +814,4 @@ void MainWindow::toggleFullScreen()
         storedWindowState = windowState();
         showFullScreen();
     }
-    bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    ui->imageDetails->setVisible(showDetails && !isFullscreen);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -241,7 +241,7 @@ void MainWindow::settingsUpdated()
     // Show details in fullscreen if akready in fullscreen
     bool isFullscreen = windowState() == Qt::WindowFullScreen;
     bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    ui->imageDetails->setVisible(showDetails and isFullscreen);
+    ui->imageDetails->setVisible(showDetails && isFullscreen);
 
 }
 
@@ -813,5 +813,5 @@ void MainWindow::toggleFullScreen()
         showFullScreen();
     }
     bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    ui->imageDetails->setVisible(showDetails and !isFullscreen);
+    ui->imageDetails->setVisible(showDetails && !isFullscreen);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -152,6 +152,7 @@ void MainWindow::contextMenuEvent(QContextMenuEvent *event)
 
 void MainWindow::showEvent(QShowEvent *event)
 {
+    ui->fullscreenLabel->setMinimumHeight(menuBar()->sizeHint().height());
     QMainWindow::showEvent(event);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -332,6 +332,11 @@ void MainWindow::buildWindowTitle()
     }
 
     setWindowTitle(newString);
+    auto details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
+    ui->label->setEnabled(details);
+    if (details and newString.size() != 0) {
+        ui->label->setText(newString);
+    }
     windowHandle()->setFilePath(getCurrentFileDetails().fileInfo.absoluteFilePath());
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -152,7 +152,12 @@ void MainWindow::contextMenuEvent(QContextMenuEvent *event)
 
 void MainWindow::showEvent(QShowEvent *event)
 {
-    ui->fullscreenLabel->setMinimumHeight(menuBar()->sizeHint().height());
+    if (!menuBar()->sizeHint().isEmpty())
+    {
+        ui->fullscreenLabel->setMargin(0);
+        ui->fullscreenLabel->setMinimumHeight(menuBar()->sizeHint().height());
+    }
+
     QMainWindow::showEvent(event);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -238,6 +238,10 @@ void MainWindow::settingsUpdated()
     //slideshow timer
     slideshowTimer->setInterval(static_cast<int>(settingsManager.getDouble("slideshowtimer")*1000));
 
+    // details in fullscreen
+    auto details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
+    ui->label->setVisible(details);
+
 }
 
 void MainWindow::shortcutsUpdated()
@@ -332,10 +336,11 @@ void MainWindow::buildWindowTitle()
     }
 
     setWindowTitle(newString);
-    auto details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    ui->label->setEnabled(details);
+    bool details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
     if (details and newString.size() != 0) {
         ui->label->setText(newString);
+    } else {
+        ui->label->setVisible(false);
     }
     windowHandle()->setFilePath(getCurrentFileDetails().fileInfo.absoluteFilePath());
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -239,8 +239,8 @@ void MainWindow::settingsUpdated()
     slideshowTimer->setInterval(static_cast<int>(settingsManager.getDouble("slideshowtimer")*1000));
 
     // details in fullscreen
-    bool details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    ui->imageDetails->setVisible(details);
+    bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
+    ui->imageDetails->setVisible(showDetails);
 
 }
 
@@ -336,8 +336,8 @@ void MainWindow::buildWindowTitle()
     }
 
     setWindowTitle(newString);
-    bool details = qvApp->getSettingsManager().getBoolean("fullscreendetails");
-    if (details and newString.isEmpty()) {
+    bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
+    if (showDetails and newString.isEmpty()) {
         ui->imageDetails->setText(newString);
     }
     windowHandle()->setFilePath(getCurrentFileDetails().fileInfo.absoluteFilePath());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -238,8 +238,10 @@ void MainWindow::settingsUpdated()
     //slideshow timer
     slideshowTimer->setInterval(static_cast<int>(settingsManager.getDouble("slideshowtimer")*1000));
 
-    // details in fullscreen
-    ui->imageDetails->setVisible(false);
+    // Show details in fullscreen if akready in fullscreen
+    bool isFullscreen = windowState() == Qt::WindowFullScreen;
+    bool showDetails = qvApp->getSettingsManager().getBoolean("fullscreendetails");
+    ui->imageDetails->setVisible(showDetails and isFullscreen);
 
 }
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -30,6 +30,19 @@
     <property name="bottomMargin">
      <number>0</number>
     </property>
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="lineWidth">
+       <number>3</number>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -31,7 +31,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QLabel" name="label">
+     <widget class="QLabel" name="imageDetails">
       <property name="enabled">
        <bool>false</bool>
       </property>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -31,7 +31,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QLabel" name="imageDetails">
+     <widget class="QLabel" name="fullscreenLabel">
       <property name="enabled">
        <bool>false</bool>
       </property>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -34,7 +34,11 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QLabel" name="fullscreenLabel"/>
+     <widget class="QLabel" name="fullscreenLabel">
+      <property name="margin">
+       <number>3</number>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -34,11 +34,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QLabel" name="fullscreenLabel">
-      <property name="margin">
-       <number>6</number>
-      </property>
-     </widget>
+     <widget class="QLabel" name="fullscreenLabel"/>
     </item>
    </layout>
   </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -18,6 +18,9 @@
     <enum>Qt::LeftToRight</enum>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>0</number>
+    </property>
     <property name="leftMargin">
      <number>0</number>
     </property>
@@ -32,14 +35,8 @@
     </property>
     <item>
      <widget class="QLabel" name="fullscreenLabel">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="lineWidth">
-       <number>3</number>
-      </property>
-      <property name="text">
-       <string/>
+      <property name="margin">
+       <number>6</number>
       </property>
      </widget>
     </item>

--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -167,6 +167,8 @@ void QVOptionsDialog::syncSettings(bool defaults, bool makeConnections)
     syncCheckbox(ui->saveRecentsCheckbox, "saverecents", defaults, makeConnections);
     // updatenotifications
     syncCheckbox(ui->updateCheckbox, "updatenotifications", defaults, makeConnections);
+    // fullscreendetails
+    syncCheckbox(ui->detailsInFullscreen, "fullscreendetails", defaults, makeConnections);
 }
 
 void QVOptionsDialog::syncCheckbox(QCheckBox *checkbox, const QString &key, bool defaults, bool makeConnection)

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -91,7 +91,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <spacer name="horizontalSpacer_4">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -104,7 +104,7 @@
          </property>
         </spacer>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_6">
          <property name="toolTip">
           <string>Control when the window should resize to fit the image's actual size</string>
@@ -114,7 +114,7 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <widget class="QComboBox" name="windowResizeComboBox">
          <property name="toolTip">
           <string>Control when the window should resize to fit the image's actual size</string>
@@ -139,14 +139,14 @@
          </item>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="minWindowResizeLabel">
          <property name="text">
           <string>Minimum size:</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QSpinBox" name="minWindowResizeSpinBox">
          <property name="toolTip">
           <string>Control the minimum size that the window should reach when matching the image's actual size</string>
@@ -168,7 +168,7 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="maxWindowResizeLabel">
          <property name="toolTip">
           <string>Control the maximum size that the window should reach when matching the image's actual size</string>
@@ -178,7 +178,7 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QSpinBox" name="maxWindowResizeSpinBox">
          <property name="toolTip">
           <string>Control the maximum size that the window should reach when matching the image's actual size</string>
@@ -200,7 +200,7 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <spacer name="horizontalSpacer_3">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -213,14 +213,14 @@
          </property>
         </spacer>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QCheckBox" name="menubarCheckbox">
          <property name="text">
           <string>Show menubar</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QCheckBox" name="darkTitlebarCheckbox">
          <property name="toolTip">
           <string>Choose whether or not the titlebar should always be dark regardless of your chosen macOS appearance</string>
@@ -230,6 +230,13 @@
          </property>
          <property name="checked">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="detailsInFullscreen">
+         <property name="text">
+          <string>Also show in fullscren</string>
          </property>
         </widget>
        </item>

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>384</width>
-    <height>404</height>
+    <width>401</width>
+    <height>408</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -213,13 +213,6 @@
          </property>
         </spacer>
        </item>
-       <item row="12" column="1">
-        <widget class="QCheckBox" name="menubarCheckbox">
-         <property name="text">
-          <string>Show menubar</string>
-         </property>
-        </widget>
-       </item>
        <item row="11" column="1">
         <widget class="QCheckBox" name="darkTitlebarCheckbox">
          <property name="toolTip">
@@ -233,10 +226,20 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
-        <widget class="QCheckBox" name="detailsInFullscreen">
+       <item row="12" column="1">
+        <widget class="QCheckBox" name="menubarCheckbox">
          <property name="text">
-          <string>Also show in fullscren</string>
+          <string>Show menubar</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1">
+        <widget class="QCheckBox" name="detailsInFullscreen">
+         <property name="toolTip">
+          <string>Choose whether or not to display a label that displays the titlebar text while in fullscreen</string>
+         </property>
+         <property name="text">
+          <string>Show titlebar text in fullscreen</string>
          </property>
         </widget>
        </item>

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -94,6 +94,7 @@ void SettingsManager::initializeSettingsLibrary()
     settingsLibrary.insert("bgcolorenabled", {true, {}});
     settingsLibrary.insert("bgcolor", {"#212121", {}});
     settingsLibrary.insert("titlebarmode", {1, {}});
+    settingsLibrary.insert("fullscreendetails", {false, {}});
     settingsLibrary.insert("windowresizemode", {1, {}});
     settingsLibrary.insert("minwindowresizedpercentage", {20, {}});
     settingsLibrary.insert("maxwindowresizedpercentage", {70, {}});


### PR DESCRIPTION
I just added a label to show what would be the name of the main window in fullscreen.

I'm not sure I put the right call in the right place but the idea is here and it seems to work in all cases:

* Starting as fullscreen
* Enabling/disabling in preferences 

Also to not add too much code, if there no text it will show an empty label (small white line at the top) not sure if it's acceptable for you (in fact I tried, but did not manage to do it).
