### PR TITLE
Fix unable to rename on Windows(#439)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -830,7 +830,11 @@ void MainWindow::rename()
 
     auto *renameDialog = new QVRenameDialog(this, getCurrentFileDetails().fileInfo);
     connect(renameDialog, &QVRenameDialog::newFileToOpen, this, &MainWindow::openFile);
-
+    connect(renameDialog, &QVRenameDialog::readyToRenameFile, this, [this] () {
+        if (auto device = graphicsView->getLoadedMovie().device()) {
+            device->close();
+        }
+    });
 
     renameDialog->open();
 }

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -183,6 +183,8 @@ void QVImageCore::loadPixmap(const ReadData &readData, bool fromCache)
 
     if (currentFileDetails.isMovieLoaded)
         loadedMovie.start();
+    else if (auto device = loadedMovie.device())
+        device->close();
 
     emit fileChanged();
 

--- a/src/qvrenamedialog.cpp
+++ b/src/qvrenamedialog.cpp
@@ -32,6 +32,8 @@ void QVRenameDialog::onFinished(int result)
         const auto newFileName = textValue();
         const auto newFilePath = QDir::cleanPath(fileInfo.absolutePath() + QDir::separator() + newFileName);
 
+        emit readyToRenameFile();
+
         if (fileInfo.absoluteFilePath() != newFilePath)
         {
             if (QFile::rename(fileInfo.absoluteFilePath(), newFilePath))

--- a/src/qvrenamedialog.h
+++ b/src/qvrenamedialog.h
@@ -14,6 +14,7 @@ public:
 
 signals:
     void newFileToOpen(const QString &filePath);
+    void readyToRenameFile();
 
 protected:
     void showEvent(QShowEvent *event) override;


### PR DESCRIPTION
## Brief ##
This PR attempts to fix #439.

After some digging in Qt source codes, I found that the renaming issue is caused by the internal `QImageReader` in `QVImageCore::loadedMovie`. `QImageReader` will open file and in implementation for Windows, it opens file without [`FILE_SHARE_DELETE`](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea) flag([ref to Qt's implementation](https://github.com/qt/qtbase/blob/dev/src/corelib/io/qfsfileengine_win.cpp#L103)), hence users would be unable to rename file opened by qView.

## Solution ##
 - When pixmap loaded, close `loadedMovie::device()` if it is not a movie.
 - For movie case, close the device before renaming. Here I added a new signal `QVRenameDialog::readyToRename` to make developers able to inject action before renaming.