### PR TITLE
Fix GitHub spelling

### DIFF
--- a/i18n/qview_bg.ts
+++ b/i18n/qview_bg.ts
@@ -393,8 +393,8 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
-        <translation>Компилирано с Qt %1 (%2)&lt;br&gt;Програмният код е достъпен под GPLv3 на &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Иконката е създадена от Guilhem от Noun проектът&lt;br&gt;Запазени права © %3 jurplel и qView сътрудниците</translation>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <translation>Компилирано с Qt %1 (%2)&lt;br&gt;Програмният код е достъпен под GPLv3 на &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Иконката е създадена от Guilhem от Noun проектът&lt;br&gt;Запазени права © %3 jurplel и qView сътрудниците</translation>
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="90"/>

--- a/i18n/qview_bn.ts
+++ b/i18n/qview_bn.ts
@@ -392,7 +392,7 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qview_de.ts
+++ b/i18n/qview_de.ts
@@ -393,8 +393,8 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
-        <translation>Erstellt mit Qt %1 (%2)&lt;br&gt;Der Quellcode steht unter der GPLv3-Lizenz und ist verfügbar auf &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt; Programmsymbol erstellt von Guilhem vom Noun Project&lt;br&gt;Copyright © %3 jurplel und zu qView Beitragende</translation>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <translation>Erstellt mit Qt %1 (%2)&lt;br&gt;Der Quellcode steht unter der GPLv3-Lizenz und ist verfügbar auf &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt; Programmsymbol erstellt von Guilhem vom Noun Project&lt;br&gt;Copyright © %3 jurplel und zu qView Beitragende</translation>
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="90"/>

--- a/i18n/qview_es.ts
+++ b/i18n/qview_es.ts
@@ -392,7 +392,7 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qview_fr.ts
+++ b/i18n/qview_fr.ts
@@ -393,8 +393,8 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
-        <translation>Conçu avec Qt %1 (%2) &lt;br&gt; Code source disponible sous GPLv3 sur &lt;a style = &quot;color: # 03A9F4; text-decoration: none;&quot; href = &quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icône glyphe créé par Guilhem à partir du projet Noun&lt;br&gt;Copyright © %3 contributeurs qView et jurplel</translation>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <translation>Conçu avec Qt %1 (%2) &lt;br&gt; Code source disponible sous GPLv3 sur &lt;a style = &quot;color: # 03A9F4; text-decoration: none;&quot; href = &quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icône glyphe créé par Guilhem à partir du projet Noun&lt;br&gt;Copyright © %3 contributeurs qView et jurplel</translation>
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="90"/>

--- a/i18n/qview_ko.ts
+++ b/i18n/qview_ko.ts
@@ -393,8 +393,8 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
-        <translation>Qt %1 (%2)로 빌드됨&lt;br&gt;소스 코드는 &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;깃허브(Github)&lt;/a&gt;에서 GPLv3 라이선스 하에 사용 가능&lt;br&gt;나운 프로젝트(Noun Project)의 기엠(Guilhem)이 만든 아이콘 글리프를 사용함&lt;br&gt;© %3 jurplel과 qView 기여자들</translation>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <translation>Qt %1 (%2)로 빌드됨&lt;br&gt;소스 코드는 &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;깃허브(GitHub)&lt;/a&gt;에서 GPLv3 라이선스 하에 사용 가능&lt;br&gt;나운 프로젝트(Noun Project)의 기엠(Guilhem)이 만든 아이콘 글리프를 사용함&lt;br&gt;© %3 jurplel과 qView 기여자들</translation>
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="90"/>

--- a/i18n/qview_nb_NO.ts
+++ b/i18n/qview_nb_NO.ts
@@ -393,7 +393,7 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
         <translation type="unfinished">Bygd med Qt %1 (%2)&lt;br&gt;Kildekode tilgengelig, lisensiert GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph laget av Guilhem fra Noun-prosjektet&lt;br&gt;Opphavsrett © %3 jurplel og qView-bidragsytere</translation>
     </message>
     <message>

--- a/i18n/qview_pt.ts
+++ b/i18n/qview_pt.ts
@@ -393,8 +393,8 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
-        <translation>Compilado com Qt %1 (%2)&lt;br&gt;Código fonte disponível nos termos da GPLv3 em &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Ícone criado por Guilhem do Noun Project&lt;br&gt;Copyright © %3 jurplel e todos os colaboradores qView</translation>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <translation>Compilado com Qt %1 (%2)&lt;br&gt;Código fonte disponível nos termos da GPLv3 em &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Ícone criado por Guilhem do Noun Project&lt;br&gt;Copyright © %3 jurplel e todos os colaboradores qView</translation>
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="90"/>

--- a/i18n/qview_pt_PT.ts
+++ b/i18n/qview_pt_PT.ts
@@ -393,8 +393,8 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
-        <translation>Compilado com Qt %1 (%2)&lt;br&gt;Código fonte disponível nos termos da GPLv3 em &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Ícone criado por Guilhem do Noun Project&lt;br&gt;Copyright © %3 jurplel e todos os colaboradores qView</translation>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <translation>Compilado com Qt %1 (%2)&lt;br&gt;Código fonte disponível nos termos da GPLv3 em &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Ícone criado por Guilhem do Noun Project&lt;br&gt;Copyright © %3 jurplel e todos os colaboradores qView</translation>
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="90"/>

--- a/i18n/qview_ru.ts
+++ b/i18n/qview_ru.ts
@@ -393,8 +393,8 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
-        <translation>Построен на Qt %1 (%2)&lt;br&gt;исходный код доступен под лицензией GPLv3 &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph создан Guilhem из Noun Project&lt;br&gt;Copyright © %3 участники jurplel and qView</translation>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <translation>Построен на Qt %1 (%2)&lt;br&gt;исходный код доступен под лицензией GPLv3 &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph создан Guilhem из Noun Project&lt;br&gt;Copyright © %3 участники jurplel and qView</translation>
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="90"/>

--- a/i18n/template.ts
+++ b/i18n/template.ts
@@ -392,7 +392,7 @@
     </message>
     <message>
         <location filename="../src/qvaboutdialog.cpp" line="62"/>
-        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;Github&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
+        <source>Built with Qt %1 (%2)&lt;br&gt;Source code available under GPLv3 on &lt;a style=&quot;color: #03A9F4; text-decoration:none;&quot; href=&quot;https://github.com/jurplel/qView&quot;&gt;GitHub&lt;/a&gt;&lt;br&gt;Icon glyph created by Guilhem from the Noun Project&lt;br&gt;Copyright © %3 jurplel and qView contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qvaboutdialog.cpp
+++ b/src/qvaboutdialog.cpp
@@ -60,7 +60,7 @@ QVAboutDialog::QVAboutDialog(double givenLatestVersionNum, QWidget *parent) :
     QFont font4 = QFont("Lato", 8 + modifier);
     font4.setStyleName("Regular");
     const QString labelText2 = tr("Built with Qt %1 (%2)<br>"
-                                  R"(Source code available under GPLv3 on <a style="color: #03A9F4; text-decoration:none;" href="https://github.com/jurplel/qView">Github</a><br>)"
+                                  R"(Source code available under GPLv3 on <a style="color: #03A9F4; text-decoration:none;" href="https://github.com/jurplel/qView">GitHub</a><br>)"
                                   "Icon glyph created by Guilhem from the Noun Project<br>"
                                   "Copyright © %3 jurplel and qView contributors")
                                   .arg(QT_VERSION_STR, QSysInfo::buildCpuArchitecture(), "2018-2020");


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.