### PR TITLE
Add checkerboard for transparent background

### DIFF
--- a/src/qvgraphicspixmapitem.cpp
+++ b/src/qvgraphicspixmapitem.cpp
@@ -1,0 +1,26 @@
+#include "qvgraphicspixmapitem.h"
+#include <QPainter>
+
+void QVGraphicsPixmapItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+{
+    const auto w = pixmap().width();
+    const auto h = pixmap().height();
+    const auto gridSize = qMax(w / 32, 8);
+    static const QColor checkerBoardColors[] = {QColor(150, 150, 150), QColor(200, 200, 200)};
+    auto colorIdx = 0;
+    auto wCursor = 0;
+    auto hCursor = 0;
+
+    for (int i = 0; i < h; i += gridSize, ++hCursor) {
+        wCursor = 0;
+        for (int j = 0; j < w; j += gridSize, ++wCursor) {
+            colorIdx = (hCursor + wCursor) % 2;
+            painter->fillRect(j, i,
+                              qMin(gridSize, w - j),
+                              qMin(gridSize, h - i),
+                              checkerBoardColors[colorIdx]);
+        }
+    }
+
+    QGraphicsPixmapItem::paint(painter, option, widget);
+}

--- a/src/qvgraphicspixmapitem.cpp
+++ b/src/qvgraphicspixmapitem.cpp
@@ -3,22 +3,24 @@
 
 void QVGraphicsPixmapItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
-    const auto w = pixmap().width();
-    const auto h = pixmap().height();
-    const auto gridSize = qMax(w / 32, 8);
-    static const QColor checkerBoardColors[] = {QColor(150, 150, 150), QColor(200, 200, 200)};
-    auto colorIdx = 0;
-    auto wCursor = 0;
-    auto hCursor = 0;
+    if (drawCheckerBoardBackground) {
+        const auto w = pixmap().width();
+        const auto h = pixmap().height();
+        const auto gridSize = qMax(w / 32, 8);
+        static const QColor checkerBoardColors[] = {QColor(150, 150, 150), QColor(200, 200, 200)};
+        auto colorIdx = 0;
+        auto wCursor = 0;
+        auto hCursor = 0;
 
-    for (int i = 0; i < h; i += gridSize, ++hCursor) {
-        wCursor = 0;
-        for (int j = 0; j < w; j += gridSize, ++wCursor) {
-            colorIdx = (hCursor + wCursor) % 2;
-            painter->fillRect(j, i,
-                              qMin(gridSize, w - j),
-                              qMin(gridSize, h - i),
-                              checkerBoardColors[colorIdx]);
+        for (int i = 0; i < h; i += gridSize, ++hCursor) {
+            wCursor = 0;
+            for (int j = 0; j < w; j += gridSize, ++wCursor) {
+                colorIdx = (hCursor + wCursor) % 2;
+                painter->fillRect(j, i,
+                                  qMin(gridSize, w - j),
+                                  qMin(gridSize, h - i),
+                                  checkerBoardColors[colorIdx]);
+            }
         }
     }
 

--- a/src/qvgraphicspixmapitem.h
+++ b/src/qvgraphicspixmapitem.h
@@ -1,0 +1,19 @@
+#ifndef QVGRAPHICSPIXMAPITEM_H
+#define QVGRAPHICSPIXMAPITEM_H
+
+#include <QGraphicsPixmapItem>
+
+class QVGraphicsPixmapItem : public QGraphicsPixmapItem
+{
+public:
+    explicit QVGraphicsPixmapItem(QGraphicsItem *parent = nullptr)
+        : QGraphicsPixmapItem(parent) {}
+
+    explicit QVGraphicsPixmapItem(const QPixmap &pixmap, QGraphicsItem *parent = nullptr)
+        : QGraphicsPixmapItem(pixmap, parent) {}
+
+private:
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+};
+
+#endif // QVGRAPHICSPIXMAPITEM_H

--- a/src/qvgraphicspixmapitem.h
+++ b/src/qvgraphicspixmapitem.h
@@ -12,8 +12,12 @@ public:
     explicit QVGraphicsPixmapItem(const QPixmap &pixmap, QGraphicsItem *parent = nullptr)
         : QGraphicsPixmapItem(pixmap, parent) {}
 
+    void setDrawCheckerBoardBackground(bool en) {
+        drawCheckerBoardBackground = en;
+    }
 private:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    bool drawCheckerBoardBackground{true};
 };
 
 #endif // QVGRAPHICSPIXMAPITEM_H

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -11,6 +11,7 @@
 #include <QtMath>
 #include <QGestureEvent>
 #include <QScrollBar>
+#include "qvgraphicspixmapitem.h"
 
 QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
 {
@@ -59,7 +60,8 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     connect(expensiveScaleTimerNew, &QTimer::timeout, this, [this]{scaleExpensively();});
 
 
-    loadedPixmapItem = new QGraphicsPixmapItem();
+//    loadedPixmapItem = new QGraphicsPixmapItem();
+    loadedPixmapItem = new QVGraphicsPixmapItem();
     scene->addItem(loadedPixmapItem);
 
     // Connect to settings signal

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -59,8 +59,6 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     expensiveScaleTimerNew->setInterval(50);
     connect(expensiveScaleTimerNew, &QTimer::timeout, this, [this]{scaleExpensively();});
 
-
-//    loadedPixmapItem = new QGraphicsPixmapItem();
     loadedPixmapItem = new QVGraphicsPixmapItem();
     scene->addItem(loadedPixmapItem);
 
@@ -643,6 +641,8 @@ void QVGraphicsView::settingsUpdated()
         newBrush.setColor(newColor);
     }
     setBackgroundBrush(newBrush);
+
+    loadedPixmapItem->setDrawCheckerBoardBackground(settingsManager.getBoolean("checkerboardBackground"));
 
     //filtering
     if (settingsManager.getBoolean("filteringenabled"))

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -9,6 +9,8 @@
 #include <QTimer>
 #include <QFileInfo>
 
+class QVGraphicsPixmapItem;
+
 class QVGraphicsView : public QGraphicsView
 {
     Q_OBJECT
@@ -116,7 +118,7 @@ private slots:
 private:
 
 
-    QGraphicsPixmapItem *loadedPixmapItem;
+    QVGraphicsPixmapItem *loadedPixmapItem;
 
     bool isFilteringEnabled;
     bool isScalingEnabled;

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -201,7 +201,7 @@ void QVImageCore::loadPixmap(const ReadData &readData, bool fromCache)
 
     emit fileChanged();
 
-    QtConcurrent::run(&QVImageCore::requestCaching, this);
+    QtConcurrent::run(std::mem_fn(&QVImageCore::requestCaching), this);
 }
 
 void QVImageCore::closeImage()

--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -125,6 +125,9 @@ void QVOptionsDialog::syncSettings(bool defaults, bool makeConnections)
     transientSettings.insert("bgcolor", ui->bgColorButton->text());
     updateBgColorButton();
     connect(ui->bgColorButton, &QPushButton::clicked, this, &QVOptionsDialog::bgColorButtonClicked);
+
+    syncCheckbox(ui->checkerboardBackgroundCheckbox, "checkerboardBackground", defaults, makeConnections);
+
     // titlebarmode
     syncRadioButtons({ui->titlebarRadioButton0, ui->titlebarRadioButton1,
                      ui->titlebarRadioButton2, ui->titlebarRadioButton3}, "titlebarmode", defaults, makeConnections);

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -50,7 +50,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label">
          <property name="toolTip">
           <string>Changes the amount of information displayed in the titlebar</string>
@@ -60,14 +60,14 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QRadioButton" name="titlebarRadioButton0">
          <property name="text">
           <string>&amp;Basic</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QRadioButton" name="titlebarRadioButton1">
          <property name="text">
           <string>&amp;Minimal</string>
@@ -77,21 +77,21 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <widget class="QRadioButton" name="titlebarRadioButton2">
          <property name="text">
           <string>&amp;Practical</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <widget class="QRadioButton" name="titlebarRadioButton3">
          <property name="text">
           <string>&amp;Verbose</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <spacer name="horizontalSpacer_4">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -104,7 +104,7 @@
          </property>
         </spacer>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_6">
          <property name="toolTip">
           <string>Control when the window should resize to fit the image's actual size</string>
@@ -114,7 +114,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QComboBox" name="windowResizeComboBox">
          <property name="toolTip">
           <string>Control when the window should resize to fit the image's actual size</string>
@@ -139,14 +139,14 @@
          </item>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="minWindowResizeLabel">
          <property name="text">
           <string>Minimum size:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QSpinBox" name="minWindowResizeSpinBox">
          <property name="toolTip">
           <string>Control the minimum size that the window should reach when matching the image's actual size</string>
@@ -168,7 +168,7 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="maxWindowResizeLabel">
          <property name="toolTip">
           <string>Control the maximum size that the window should reach when matching the image's actual size</string>
@@ -178,7 +178,7 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QSpinBox" name="maxWindowResizeSpinBox">
          <property name="toolTip">
           <string>Control the maximum size that the window should reach when matching the image's actual size</string>
@@ -200,7 +200,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <spacer name="horizontalSpacer_3">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -213,7 +213,7 @@
          </property>
         </spacer>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QCheckBox" name="darkTitlebarCheckbox">
          <property name="toolTip">
           <string>Choose whether or not the titlebar should always be dark regardless of your chosen macOS appearance</string>
@@ -226,14 +226,14 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QCheckBox" name="menubarCheckbox">
          <property name="text">
           <string>Show menubar</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QCheckBox" name="detailsInFullscreen">
          <property name="toolTip">
           <string>Choose whether or not to display the titlebar text while in fullscreen</string>
@@ -243,10 +243,17 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="15" column="1">
         <widget class="QCheckBox" name="quitOnLastWindowCheckbox">
          <property name="text">
           <string>&amp;Quit on last window closed</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QCheckBox" name="checkerboardBackgroundCheckbox">
+         <property name="text">
+          <string>Checkerboard for transparent background </string>
          </property>
         </widget>
        </item>

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -149,6 +149,7 @@ void SettingsManager::initializeSettingsLibrary()
     // Window
     settingsLibrary.insert("bgcolorenabled", {true, {}});
     settingsLibrary.insert("bgcolor", {"#212121", {}});
+    settingsLibrary.insert("checkerboardBackground", {false, {}});
     settingsLibrary.insert("titlebarmode", {1, {}});
     settingsLibrary.insert("windowresizemode", {1, {}});
     settingsLibrary.insert("minwindowresizedpercentage", {20, {}});

--- a/src/src.pri
+++ b/src/src.pri
@@ -2,6 +2,7 @@ SOURCES += \
     $$PWD/main.cpp \
     $$PWD/mainwindow.cpp \
     $$PWD/openwith.cpp \
+    $$PWD/qvgraphicspixmapitem.cpp \
     $$PWD/qvgraphicsview.cpp \
     $$PWD/qvoptionsdialog.cpp \
     $$PWD/qvapplication.cpp \
@@ -22,6 +23,7 @@ win32:!CONFIG(NO_WIN32):SOURCES += $$PWD/qvwin32functions.cpp
 HEADERS += \
     $$PWD/mainwindow.h \
     $$PWD/openwith.h \
+    $$PWD/qvgraphicspixmapitem.h \
     $$PWD/qvgraphicsview.h \
     $$PWD/qvoptionsdialog.h \
     $$PWD/qvapplication.h \


### PR DESCRIPTION
As requested in #489, this PR attempts to implement checkerboard for transparent background. A checkbox in option window was also added to let users choose to use or not. Here's the result:

![image](https://user-images.githubusercontent.com/2656666/164521204-b495e84f-6f97-48fe-96e5-19a9f4dfc6ed.png)

