### PR TITLE
Improve scroll to zoom experience with high resolution touchpads

### DIFF
--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -38,14 +38,14 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     isCursorZoomEnabled = true;
     cropMode = 0;
     scaleFactor = 1.25;
-    lastZoomEventPos = QPoint(-1, -1);
-    lastZoomRoundingError = QPointF();
 
     // Initialize other variables
     currentScale = 1.0;
     scaledSize = QSize();
     maxScalingTwoSize = 3;
     isOriginalSize = false;
+    lastZoomEventPos = QPoint(-1, -1);
+    lastZoomRoundingError = QPointF();
 
     zoomBasisScaleFactor = 1.0;
 

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -38,6 +38,8 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     isCursorZoomEnabled = true;
     cropMode = 0;
     scaleFactor = 1.25;
+    lastZoomEventPos = QPoint(-1, -1);
+    lastZoomRoundingError = QPointF();
 
     // Initialize other variables
     currentScale = 1.0;
@@ -259,7 +261,12 @@ void QVGraphicsView::zoom(qreal scaleFactor, const QPoint &pos)
         return;
     }
 
-    const QPointF scenePos = mapToScene(pos);
+    if (pos != lastZoomEventPos)
+    {
+        lastZoomEventPos = pos;
+        lastZoomRoundingError = QPointF();
+    }
+    const QPointF scenePos = mapToScene(pos) - lastZoomRoundingError;
 
     zoomBasisScaleFactor *= scaleFactor;
     setTransform(QTransform(zoomBasis).scale(zoomBasisScaleFactor, zoomBasisScaleFactor));
@@ -272,6 +279,7 @@ void QVGraphicsView::zoom(qreal scaleFactor, const QPoint &pos)
         const QPointF move = p1mouse - pos;
         horizontalScrollBar()->setValue(move.x() + horizontalScrollBar()->value());
         verticalScrollBar()->setValue(move.y() + verticalScrollBar()->value());
+        lastZoomRoundingError = mapToScene(pos) - scenePos;
     }
     else
     {

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -173,17 +173,20 @@ void QVGraphicsView::wheelEvent(QWheelEvent *event)
         return;
     }
 
-    int angleDelta;
+    const int yDelta = event->angleDelta().y();
+    const qreal yScale = 120.0;
 
-    if (event->angleDelta().y() == 0)
-        angleDelta = event->angleDelta().x();
-    else
-        angleDelta = event->angleDelta().y();
+    if (yDelta == 0)
+        return;
 
-    if (angleDelta > 0)
-        zoomIn(eventPos);
-    else
-        zoomOut(eventPos);
+    const qreal fractionalWheelClicks = qFabs(yDelta) / yScale;
+    const qreal zoomAmountPerWheelClick = scaleFactor - 1.0;
+    qreal zoomFactor = 1.0 + (fractionalWheelClicks * zoomAmountPerWheelClick);
+
+    if (yDelta < 0)
+        zoomFactor = qPow(zoomFactor, -1);
+
+    zoom(zoomFactor, eventPos);
 }
 
 // Functions
@@ -568,6 +571,7 @@ void QVGraphicsView::fitInViewMarginless(const QRectF &rect)
 
     isOriginalSize = false;
     currentScale = 1.0;
+    zoomBasisScaleFactor = 1.0;
 }
 
 void QVGraphicsView::fitInViewMarginless(const QGraphicsItem *item)

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -134,6 +134,8 @@ private:
     QSize scaledSize;
     bool isOriginalSize;
     qreal maxScalingTwoSize;
+    QPoint lastZoomEventPos;
+    QPointF lastZoomRoundingError;
 
     QTransform absoluteTransform;
     QTransform zoomBasis;


### PR DESCRIPTION
On my Mac laptop I prefer to use the vertical scroll gesture for zooming rather than the pinch gesture, but I noticed that scrolling to zoom didn't feel right in a couple of ways.

First, it seemed to become unresponsive or even zoom out when it's supposed to zoom in, which I figured out is due to the QWheelEvent object sometimes having all zero deltas. The original code was checking for a positive delta to zoom in, but a simple 'else' to zoom out, without ensuring a non-zero negative value is present.
![image](https://user-images.githubusercontent.com/6741660/197068167-d1a22d89-8571-4a36-a1f0-ff54d891bf50.png)

Second, the zoom speed didn't correlate to how fast the gesture was being performed, because the 'y' value reported in the pixelDelta wasn't being considered. This worked okay with mice wheels because the delta is typically the same every scroll wheel click, but with touchpads the delta varies depending on how fast the gesture is happening. The Qt docs say most mice have deltas of 120 units per wheel click (which matches the Logitech mouse I tested with), hence that number in the code.

I tested this in Windows with my Surface Laptop 3 (Precision Touchpad) as well, and it also works fine.

Although the Qt docs mention that pixelDelta() may be used instead of angleDelta() with high resolution touchpads, in practice I didn't find any benefit to using it. On Mac, the 'y' values I saw always correlated between both, just that angleDelta() is higher by a factor of 2. Windows doesn't provide pixelDelta() data. The docs also say that pixelDelta() values are unreliable on X11 due to being driver-specific.

Bonus fix: Reset Zoom wasn't fully resetting the zoom properly with the "Image scaling" setting off. When image scaling is on, `zoomBasisScaleFactor` is periodically reset to 1.0 so the problem isn't noticeable.