### PR TITLE
Optimizations for listing files in directory

### DIFF
--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -368,30 +368,26 @@ void QVApplication::defineFilterLists()
 
     auto filterString = tr("Supported Images") + " (";
     filterList.reserve(byteArrayFormats.size()-1);
-    filterRegExpList.reserve(byteArrayFormats.size()-1);
+    fileExtensionList.reserve(byteArrayFormats.size()-1);
 
     // Build the filterlist, filterstring, and filterregexplist in one loop
     for (const auto &byteArray : byteArrayFormats)
     {
-        const auto fileExtString = "*." + QString::fromUtf8(byteArray);
+        const auto fileExtension = "." + QString::fromUtf8(byteArray);
         // Qt 5.15 seems to have added pdf support for QImageReader but it is super broken in qView
-        if (fileExtString == "*.pdf")
+        if (fileExtension == ".pdf")
             continue;
 
-        filterList << fileExtString;
-        filterString += fileExtString + " ";
-
-        QString re = QRegularExpression::wildcardToRegularExpression(fileExtString);
-        filterRegExpList << QRegularExpression(re, QRegularExpression::CaseInsensitiveOption);
+        filterList << "*" + fileExtension;
+        filterString += "*" + fileExtension + " ";
+        fileExtensionList << fileExtension;
 
         // If we support jpg, we actually support the jfif, jfi, and jpe file extensions too almost certainly.
-        if (fileExtString == "*.jpg")
+        if (fileExtension == ".jpg")
         {
             filterList << "*.jpe" << "*.jfi" << "*.jfif";
             filterString += "*.jpe *.jfi *.jfif";
-            filterRegExpList << QRegularExpression(QRegularExpression::wildcardToRegularExpression("*.jpe"), QRegularExpression::CaseInsensitiveOption)
-                             << QRegularExpression(QRegularExpression::wildcardToRegularExpression("*.jfi"), QRegularExpression::CaseInsensitiveOption)
-                             << QRegularExpression(QRegularExpression::wildcardToRegularExpression("*.jfif"), QRegularExpression::CaseInsensitiveOption);
+            fileExtensionList << ".jpe" << ".jfi" << ".jfif";
         }
     }
     filterString.chop(1);

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -75,7 +75,7 @@ public:
 
     const QStringList &getNameFilterList() const { return nameFilterList; }
 
-    const QList<QRegularExpression> &getFilterRegExpList() const { return filterRegExpList; }
+    const QStringList &getFileExtensionList() const { return fileExtensionList; }
 
     const QStringList &getMimeTypeNameList() const { return mimeTypeNameList; }
 
@@ -98,7 +98,7 @@ private:
 
     QStringList filterList;
     QStringList nameFilterList;
-    QList<QRegularExpression> filterRegExpList;
+    QStringList fileExtensionList;
     QStringList mimeTypeNameList;
 
     // This order is very important

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -485,11 +485,11 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
     }
     }
 
-    const QFileInfo nextImage = getCurrentFileDetails().folderFileInfoList.value(newIndex);
-    if (!nextImage.isFile())
+    const QVImageCore::CompatibleFile nextImage = getCurrentFileDetails().folderFileInfoList.value(newIndex);
+    if (!QFileInfo(nextImage.absoluteFilePath).isFile())
         return;
 
-    loadFile(nextImage.absoluteFilePath());
+    loadFile(nextImage.absoluteFilePath);
 }
 
 void QVGraphicsView::fitInViewMarginless(const QRectF &rect)

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -233,9 +233,9 @@ void QVImageCore::closeImage()
 }
 
 // All file logic, sorting, etc should be moved to a different class or file
-QFileInfoList QVImageCore::getCompatibleFiles()
+QList<QVImageCore::CompatibleFile> QVImageCore::getCompatibleFiles()
 {
-    QFileInfoList fileInfoList;
+    QList<CompatibleFile> fileList;
 
     QMimeDatabase mimeDb;
     const auto &extensions = qvApp->getFileExtensionList();
@@ -254,13 +254,24 @@ QFileInfoList QVImageCore::getCompatibleFiles()
                 break;
             }
         }
-        if (matched || mimeTypes.contains(mimeDb.mimeTypeForFile(fileInfo).name().toUtf8()))
+        QString mimeType;
+        if (!matched || sortMode == 3)
         {
-            fileInfoList.append(fileInfo);
+            mimeType = mimeDb.mimeTypeForFile(fileInfo).name();
+        }
+        if (matched || mimeTypes.contains(mimeType))
+        {
+            fileList.append({
+                fileInfo.absoluteFilePath(),
+                name,
+                sortMode == 1 ? fileInfo.lastModified().toMSecsSinceEpoch() : 0,
+                sortMode == 2 ? fileInfo.size() : 0,
+                sortMode == 3 ? mimeType : QString()
+            });
         }
     }
 
-    return fileInfoList;
+    return fileList;
 }
 
 void QVImageCore::updateFolderInfo()
@@ -287,54 +298,49 @@ void QVImageCore::updateFolderInfo()
         collator.setNumericMode(true);
         std::sort(currentFileDetails.folderFileInfoList.begin(),
                   currentFileDetails.folderFileInfoList.end(),
-                  [&collator, this](const QFileInfo &file1, const QFileInfo &file2)
+                  [&collator, this](const CompatibleFile &file1, const CompatibleFile &file2)
         {
             if (sortDescending)
-                return collator.compare(file1.fileName(), file2.fileName()) > 0;
+                return collator.compare(file1.fileName, file2.fileName) > 0;
             else
-                return collator.compare(file1.fileName(), file2.fileName()) < 0;
+                return collator.compare(file1.fileName, file2.fileName) < 0;
         });
     }
     else if (sortMode == 1) // last modified
     {
         std::sort(currentFileDetails.folderFileInfoList.begin(),
                   currentFileDetails.folderFileInfoList.end(),
-                  [this](const QFileInfo &file1, const QFileInfo &file2)
+                  [this](const CompatibleFile &file1, const CompatibleFile &file2)
         {
             if (sortDescending)
-                return file1.lastModified() < file2.lastModified();
+                return file1.lastModified < file2.lastModified;
             else
-                return file1.lastModified() > file2.lastModified();
+                return file1.lastModified > file2.lastModified;
         });
     }
     else if (sortMode == 2) // size
     {
         std::sort(currentFileDetails.folderFileInfoList.begin(),
                   currentFileDetails.folderFileInfoList.end(),
-                  [this](const QFileInfo &file1, const QFileInfo &file2)
+                  [this](const CompatibleFile &file1, const CompatibleFile &file2)
         {
             if (sortDescending)
-                return file1.size() < file2.size();
+                return file1.size < file2.size;
             else
-                return file1.size() > file2.size();
+                return file1.size > file2.size;
         });
     }
     else if (sortMode == 3) // type
     {
-        QMimeDatabase mimeDb;
-
         QCollator collator;
         std::sort(currentFileDetails.folderFileInfoList.begin(),
                   currentFileDetails.folderFileInfoList.end(),
-                  [&mimeDb, &collator, this](const QFileInfo &file1, const QFileInfo &file2)
+                  [&collator, this](const CompatibleFile &file1, const CompatibleFile &file2)
         {
-            QMimeType mime1 = mimeDb.mimeTypeForFile(file1);
-            QMimeType mime2 = mimeDb.mimeTypeForFile(file2);
-
             if (sortDescending)
-                return collator.compare(mime1.name(), mime2.name()) > 0;
+                return collator.compare(file1.mimeType, file2.mimeType) > 0;
             else
-                return collator.compare(mime1.name(), mime2.name()) < 0;
+                return collator.compare(file1.mimeType, file2.mimeType) < 0;
         });
     }
     else if (sortMode == 4) // Random
@@ -381,7 +387,7 @@ void QVImageCore::requestCaching()
         if (index > currentFileDetails.folderFileInfoList.length()-1 || index < 0 || currentFileDetails.folderFileInfoList.isEmpty())
             continue;
 
-        QString filePath = currentFileDetails.folderFileInfoList[index].absoluteFilePath();
+        QString filePath = currentFileDetails.folderFileInfoList[index].absoluteFilePath;
         filesToPreload.append(filePath);
 
         requestCachingFile(filePath);
@@ -567,8 +573,8 @@ void QVImageCore::FileDetails::updateLoadedIndexInFolder()
     {
         // Compare absoluteFilePath first because it's way faster, but double-check with
         // QFileInfo::operator== because it respects file system case sensitivity rules
-        if (folderFileInfoList[i].absoluteFilePath().compare(targetPath, Qt::CaseInsensitive) == 0 &&
-            folderFileInfoList[i] == fileInfo)
+        if (folderFileInfoList[i].absoluteFilePath.compare(targetPath, Qt::CaseInsensitive) == 0 &&
+            QFileInfo(folderFileInfoList[i].absoluteFilePath) == fileInfo)
         {
             loadedIndexInFolder = i;
             return;

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -24,7 +24,7 @@ QVImageCore::QVImageCore(QObject *parent) : QObject(parent)
     sortMode = 0;
     sortDescending = false;
     showHiddenFiles = false;
-    allowMimeContentDetection = true;
+    allowMimeContentDetection = false;
 
     randomSortSeed = 0;
 

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -238,7 +238,7 @@ QFileInfoList QVImageCore::getCompatibleFiles()
     QFileInfoList fileInfoList;
 
     QMimeDatabase mimeDb;
-    const auto &regs = qvApp->getFilterRegExpList();
+    const auto &extensions = qvApp->getFileExtensionList();
     const auto &mimeTypes = qvApp->getMimeTypeNameList();
 
     const QFileInfoList currentFolder = currentFileDetails.fileInfo.dir().entryInfoList(QDir::Filter::Files, QDir::SortFlag::Unsorted);
@@ -246,9 +246,10 @@ QFileInfoList QVImageCore::getCompatibleFiles()
     {
         bool matched = false;
         const QString name = fileInfo.fileName();
-        for (const QRegularExpression &reg : regs)
+        for (const QString &extension : extensions)
         {
-            if (reg.match(name).hasMatch()) {
+            if (name.endsWith(extension, Qt::CaseInsensitive))
+            {
                 matched = true;
                 break;
             }

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -23,7 +23,6 @@ QVImageCore::QVImageCore(QObject *parent) : QObject(parent)
     preloadingMode = 1;
     sortMode = 0;
     sortDescending = false;
-    showHiddenFiles = false;
     allowMimeContentDetection = false;
 
     randomSortSeed = 0;
@@ -245,11 +244,7 @@ QList<QVImageCore::CompatibleFile> QVImageCore::getCompatibleFiles()
 
     QMimeDatabase::MatchMode mimeMatchMode = allowMimeContentDetection ? QMimeDatabase::MatchDefault : QMimeDatabase::MatchExtension;
 
-    QDir::Filters dirFilters = QDir::Files;
-    if (showHiddenFiles)
-        dirFilters |= QDir::Hidden;
-
-    const QFileInfoList currentFolder = currentFileDetails.fileInfo.dir().entryInfoList(dirFilters, QDir::Unsorted);
+    const QFileInfoList currentFolder = currentFileDetails.fileInfo.dir().entryInfoList(QDir::Files | QDir::Hidden, QDir::Unsorted);
     for (const QFileInfo &fileInfo : currentFolder)
     {
         bool matched = false;
@@ -571,9 +566,6 @@ void QVImageCore::settingsUpdated()
 
     //sort ascending
     sortDescending = settingsManager.getBoolean("sortdescending");
-
-    //show hidden files
-    showHiddenFiles = settingsManager.getBoolean("showhiddenfiles");
 
     //allow mime content detection
     allowMimeContentDetection = settingsManager.getBoolean("allowmimecontentdetection");

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -291,8 +291,8 @@ void QVImageCore::updateFolderInfo()
 
     currentFileDetails.folderFileInfoList = getCompatibleFiles();
 
-    QPair<QString, uint> dirInfo = {currentFileDetails.fileInfo.absoluteDir().path(),
-                                    static_cast<uint>(currentFileDetails.folderFileInfoList.count())};
+    QPair<QString, qsizetype> dirInfo = {currentFileDetails.fileInfo.absoluteDir().path(),
+                                         currentFileDetails.folderFileInfoList.count()};
     // If the current folder changed since the last image, assign a new seed for random sorting
     if (lastDirInfo != dirInfo)
     {

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -292,7 +292,7 @@ void QVImageCore::updateFolderInfo()
     currentFileDetails.folderFileInfoList = getCompatibleFiles();
 
     QPair<QString, uint> dirInfo = {currentFileDetails.fileInfo.absoluteDir().path(),
-                                    currentFileDetails.folderFileInfoList.count()};
+                                    static_cast<uint>(currentFileDetails.folderFileInfoList.count())};
     // If the current folder changed since the last image, assign a new seed for random sorting
     if (lastDirInfo != dirInfo)
     {

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -27,6 +27,8 @@ public:
         QSize baseImageSize;
         QSize loadedPixmapSize;
         QElapsedTimer timeSinceLoaded;
+
+        void updateLoadedIndexInFolder();
     };
 
     struct ReadData

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -16,10 +16,21 @@ class QVImageCore : public QObject
     Q_OBJECT
 
 public:
+    struct CompatibleFile
+    {
+        QString absoluteFilePath;
+        QString fileName;
+
+        // Only populated if needed for sorting
+        qint64 lastModified;
+        qint64 size;
+        QString mimeType;
+    };
+
     struct FileDetails
     {
         QFileInfo fileInfo;
-        QFileInfoList folderFileInfoList;
+        QList<CompatibleFile> folderFileInfoList;
         int loadedIndexInFolder = -1;
         bool isLoadRequested = false;
         bool isPixmapLoaded = false;
@@ -44,7 +55,7 @@ public:
     ReadData readFile(const QString &fileName, bool forCache);
     void loadPixmap(const ReadData &readData, bool fromCache);
     void closeImage();
-    QFileInfoList getCompatibleFiles();
+    QList<CompatibleFile> getCompatibleFiles();
     void updateFolderInfo();
     void requestCaching();
     void requestCachingFile(const QString &filePath);

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -102,6 +102,8 @@ private:
     int preloadingMode;
     int sortMode;
     bool sortDescending;
+    bool showHiddenFiles;
+    bool allowMimeContentDetection;
 
     QPair<QString, uint> lastDirInfo;
     unsigned randomSortSeed;

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -102,7 +102,6 @@ private:
     int preloadingMode;
     int sortMode;
     bool sortDescending;
-    bool showHiddenFiles;
     bool allowMimeContentDetection;
 
     QPair<QString, qsizetype> lastDirInfo;

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -105,7 +105,7 @@ private:
     bool showHiddenFiles;
     bool allowMimeContentDetection;
 
-    QPair<QString, uint> lastDirInfo;
+    QPair<QString, qsizetype> lastDirInfo;
     unsigned randomSortSeed;
 
     QStringList lastFilesPreloaded;

--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -191,8 +191,6 @@ void QVOptionsDialog::syncSettings(bool defaults, bool makeConnections)
     syncComboBox(ui->afterDeletionComboBox, "afterdelete", defaults, makeConnections);
     // askdelete
     syncCheckbox(ui->askDeleteCheckbox, "askdelete", defaults, makeConnections);
-    // showhiddenfiles
-    syncCheckbox(ui->hiddenFilesCheckbox, "showhiddenfiles", defaults, makeConnections);
     // allowmimecontentdetection
     syncCheckbox(ui->mimeContentDetectionCheckbox, "allowmimecontentdetection", defaults, makeConnections);
     // saverecents

--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -191,6 +191,10 @@ void QVOptionsDialog::syncSettings(bool defaults, bool makeConnections)
     syncComboBox(ui->afterDeletionComboBox, "afterdelete", defaults, makeConnections);
     // askdelete
     syncCheckbox(ui->askDeleteCheckbox, "askdelete", defaults, makeConnections);
+    // showhiddenfiles
+    syncCheckbox(ui->hiddenFilesCheckbox, "showhiddenfiles", defaults, makeConnections);
+    // allowmimecontentdetection
+    syncCheckbox(ui->mimeContentDetectionCheckbox, "allowmimecontentdetection", defaults, makeConnections);
     // saverecents
     syncCheckbox(ui->saveRecentsCheckbox, "saverecents", defaults, makeConnections);
     // updatenotifications

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -643,13 +643,30 @@
         </spacer>
        </item>
        <item row="14" column="1">
+        <widget class="QCheckBox" name="hiddenFilesCheckbox">
+         <property name="text">
+          <string>Show &amp;hidden files</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1">
+        <widget class="QCheckBox" name="mimeContentDetectionCheckbox">
+         <property name="text">
+          <string>Allow &amp;MIME content detection</string>
+         </property>
+         <property name="toolTip">
+          <string>Detect supported files in folder even if extension isn't recognized (may be slow with larger/network folders)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="1">
         <widget class="QCheckBox" name="saveRecentsCheckbox">
          <property name="text">
           <string>Save &amp;recent files</string>
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="17" column="1">
         <widget class="QCheckBox" name="updateCheckbox">
          <property name="text">
           <string extracomment="The notifications are for new qView releases">&amp;Update notifications on startup</string>

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -643,13 +643,6 @@
         </spacer>
        </item>
        <item row="14" column="1">
-        <widget class="QCheckBox" name="hiddenFilesCheckbox">
-         <property name="text">
-          <string>Show &amp;hidden files</string>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="1">
         <widget class="QCheckBox" name="mimeContentDetectionCheckbox">
          <property name="text">
           <string>Allow &amp;MIME content detection</string>
@@ -659,14 +652,14 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="15" column="1">
         <widget class="QCheckBox" name="saveRecentsCheckbox">
          <property name="text">
           <string>Save &amp;recent files</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="16" column="1">
         <widget class="QCheckBox" name="updateCheckbox">
          <property name="text">
           <string extracomment="The notifications are for new qView releases">&amp;Update notifications on startup</string>

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -177,7 +177,7 @@ void SettingsManager::initializeSettingsLibrary()
     settingsLibrary.insert("afterdelete", {2, {}});
     settingsLibrary.insert("askdelete", {true, {}});
     settingsLibrary.insert("showhiddenfiles", {false, {}});
-    settingsLibrary.insert("allowmimecontentdetection", {true, {}});
+    settingsLibrary.insert("allowmimecontentdetection", {false, {}});
     settingsLibrary.insert("saverecents", {true, {}});
     settingsLibrary.insert("updatenotifications", {false, {}});
 }

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -176,6 +176,8 @@ void SettingsManager::initializeSettingsLibrary()
     settingsLibrary.insert("slideshowtimer", {5, {}});
     settingsLibrary.insert("afterdelete", {2, {}});
     settingsLibrary.insert("askdelete", {true, {}});
+    settingsLibrary.insert("showhiddenfiles", {false, {}});
+    settingsLibrary.insert("allowmimecontentdetection", {true, {}});
     settingsLibrary.insert("saverecents", {true, {}});
     settingsLibrary.insert("updatenotifications", {false, {}});
 }

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -176,7 +176,6 @@ void SettingsManager::initializeSettingsLibrary()
     settingsLibrary.insert("slideshowtimer", {5, {}});
     settingsLibrary.insert("afterdelete", {2, {}});
     settingsLibrary.insert("askdelete", {true, {}});
-    settingsLibrary.insert("showhiddenfiles", {false, {}});
     settingsLibrary.insert("allowmimecontentdetection", {false, {}});
     settingsLibrary.insert("saverecents", {true, {}});
     settingsLibrary.insert("updatenotifications", {false, {}});


### PR DESCRIPTION
This addresses slowness when switching images as discussed in #476, #509, #514. While there may be more that could be done, and I only tested with a moderately sized folder (~1500 images), I think this is a good first step that noticeably speeds things up with some relatively simple and (IMO) safe code changes.