### PR TITLE
Partial workaround for slow Open With menu updating on Mac

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -376,11 +376,18 @@ void MainWindow::populateOpenWithMenu(const QList<OpenWith::OpenWithItem> openWi
             if (i < openWithItems.length())
             {
                 auto openWithItem = openWithItems.value(i);
+                auto data = action->data().toList();
 
                 action->setVisible(true);
+
+#ifdef Q_OS_MACOS
+                const auto &existingOpenWithItem = data.at(1).value<OpenWith::OpenWithItem>();
+                if (openWithItem.exec == existingOpenWithItem.exec && openWithItem.args == existingOpenWithItem.args)
+                    continue;
+#endif
+
                 action->setText(openWithItem.name);
                 action->setIcon(openWithItem.icon);
-                auto data = action->data().toList();
                 data.replace(1, QVariant::fromValue(openWithItem));
                 action->setData(data);
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -398,7 +398,6 @@ void MainWindow::populateOpenWithMenu(const QList<OpenWith::OpenWithItem> openWi
             else
             {
                 action->setVisible(false);
-                action->setText(tr("Empty"));
             }
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -381,9 +381,9 @@ void MainWindow::populateOpenWithMenu(const QList<OpenWith::OpenWithItem> openWi
                 action->setVisible(true);
 
 #ifdef Q_OS_MACOS
-                // On macOS, it's relatively expensive to call setIcon() with a non-empty icon, or setData() if the
-                // action has a non-empty icon. So we'll avoid updating this action if possible. If we do need to update
-                // it, clear out the icon and call setData() first to at least avoid half of the performance hit.
+                // On macOS, it's relatively expensive to call setIcon() with a non-empty icon, or setData()/setText()
+                // if the action has a non-empty icon. So we'll avoid updating this action if possible. If we do need
+                // to update it, clear out the icon and make the other updates first to improve performance.
                 const auto &existingOpenWithItem = data.at(1).value<OpenWith::OpenWithItem>();
                 if (openWithItem.exec == existingOpenWithItem.exec && openWithItem.args == existingOpenWithItem.args)
                     continue;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -381,15 +381,19 @@ void MainWindow::populateOpenWithMenu(const QList<OpenWith::OpenWithItem> openWi
                 action->setVisible(true);
 
 #ifdef Q_OS_MACOS
+                // On macOS, it's relatively expensive to call setIcon() with a non-empty icon, or setData() if the
+                // action has a non-empty icon. So we'll avoid updating this action if possible. If we do need to update
+                // it, clear out the icon and call setData() first to at least avoid half of the performance hit.
                 const auto &existingOpenWithItem = data.at(1).value<OpenWith::OpenWithItem>();
                 if (openWithItem.exec == existingOpenWithItem.exec && openWithItem.args == existingOpenWithItem.args)
                     continue;
+                action->setIcon(QIcon());
 #endif
 
-                action->setText(openWithItem.name);
-                action->setIcon(openWithItem.icon);
                 data.replace(1, QVariant::fromValue(openWithItem));
                 action->setData(data);
+                action->setText(openWithItem.name);
+                action->setIcon(openWithItem.icon);
             }
             else
             {


### PR DESCRIPTION
[As you know](https://github.com/jurplel/qView/issues/476#issuecomment-1014841726), `QAction::setIcon` is causing a slowdown when switching images on macOS. Actually, `QAction::setData` is too if the action has an icon. Both functions trigger a `QEvent::ActionChanged` event which I believe somehow ends up causing the icon to be re-rendered. I determined this with a profiler while switching between a bunch of images:
<img width="905" alt="Screenshot 2022-10-30 at 9 45 47 PM" src="https://user-images.githubusercontent.com/6741660/198914935-d36fa075-3de1-4501-bee9-b1b045134cb6.png">

Although I unfortunately don't have a super-genius idea of how to fix it, I did at least come up with this workaround that helps in a lot of cases. Namely, if the Open With items end up being the same after switching images, such as when switching between files with the same extension, this avoids the slowness.