### PR TITLE
Color space support

### DIFF
--- a/qView.pro
+++ b/qView.pro
@@ -74,6 +74,18 @@ macx {
     }
 }
 
+# Linux specific stuff
+linux {
+    !CONFIG(NO_X11) {
+        LIBS += -lX11
+        DEFINES += X11_LOADED
+
+        equals(QT_MAJOR_VERSION, 5) {
+            QT += x11extras
+        }
+    }
+}
+
 # Stuff for make install
 # To use a custom prefix: qmake PREFIX=/usr
 # An environment variable will also work: PREFIX=/usr qmake

--- a/qView.pro
+++ b/qView.pro
@@ -42,7 +42,7 @@ win32 {
 
     # To build without win32: qmake CONFIG+=NO_WIN32
     !CONFIG(NO_WIN32) {
-        LIBS += -lshell32 -luser32 -lole32 -lshlwapi
+        LIBS += -lshell32 -luser32 -lole32 -lshlwapi -lgdi32
         DEFINES += WIN32_LOADED
         message("Linked to win32 api")
     }

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -222,38 +222,6 @@ void QVApplication::recentsMenuUpdated()
 #endif
 }
 
-qint64 QVApplication::getPreviouslyRecordedFileSize(const QString &fileName)
-{
-    auto previouslyRecordedFileSizePtr = previouslyRecordedFileSizes.object(fileName);
-    qint64 previouslyRecordedFileSize = 0;
-
-    if (previouslyRecordedFileSizePtr)
-        previouslyRecordedFileSize = *previouslyRecordedFileSizePtr;
-
-    return previouslyRecordedFileSize;
-}
-
-void QVApplication::setPreviouslyRecordedFileSize(const QString &fileName, long long *fileSize)
-{
-    previouslyRecordedFileSizes.insert(fileName, fileSize);
-}
-
-QSize QVApplication::getPreviouslyRecordedImageSize(const QString &fileName)
-{
-    auto previouslyRecordedImageSizePtr = previouslyRecordedImageSizes.object(fileName);
-    QSize previouslyRecordedImageSize = QSize();
-
-    if (previouslyRecordedImageSizePtr)
-        previouslyRecordedImageSize = *previouslyRecordedImageSizePtr;
-
-    return previouslyRecordedImageSize;
-}
-
-void QVApplication::setPreviouslyRecordedImageSize(const QString &fileName, QSize *imageSize)
-{
-    previouslyRecordedImageSizes.insert(fileName, imageSize);
-}
-
 void QVApplication::addToLastActiveWindows(MainWindow *window)
 {
     if (!window)

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -47,14 +47,6 @@ public:
 
     void recentsMenuUpdated();
 
-    qint64 getPreviouslyRecordedFileSize(const QString &fileName);
-
-    void setPreviouslyRecordedFileSize(const QString &fileName, long long *fileSize);
-
-    QSize getPreviouslyRecordedImageSize(const QString &fileName);
-
-    void setPreviouslyRecordedImageSize(const QString &fileName, QSize *imageSize);
-
     void addToLastActiveWindows(MainWindow *window);
 
     void deleteFromLastActiveWindows(MainWindow *window);
@@ -92,9 +84,6 @@ private:
     QMenu *dockMenu;
 
     QMenuBar *menuBar;
-
-    QCache<QString, qint64> previouslyRecordedFileSizes;
-    QCache<QString, QSize> previouslyRecordedImageSizes;
 
     QStringList filterList;
     QStringList nameFilterList;

--- a/src/qvcocoafunctions.h
+++ b/src/qvcocoafunctions.h
@@ -30,6 +30,8 @@ public:
     static QList<OpenWith::OpenWithItem> getOpenWithItems(const QString &filePath);
 
     static QString deleteFile(const QString &filePath);
+
+    static QByteArray getIccProfileForWindow(const QWindow *window);
 };
 
 #endif // QVCOCOAFUNCTIONS_H

--- a/src/qvcocoafunctions.mm
+++ b/src/qvcocoafunctions.mm
@@ -219,3 +219,18 @@ QString QVCocoaFunctions::deleteFile(const QString &filePath)
 
     return QString::fromNSString(resultUrl.absoluteString);
 }
+
+QByteArray QVCocoaFunctions::getIccProfileForWindow(const QWindow *window)
+{
+    NSView *view = reinterpret_cast<NSView*>(window->winId());
+    NSColorSpace *nsColorSpace = view.window.colorSpace;
+    if (nsColorSpace)
+    {
+        NSData *iccProfileData = nsColorSpace.ICCProfileData;
+        if (iccProfileData)
+        {
+            return QByteArray::fromNSData(iccProfileData);
+        }
+    }
+    return {};
+}

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -142,7 +142,7 @@ private:
     QTransform zoomBasis;
     qreal zoomBasisScaleFactor;
 
-    QVImageCore imageCore;
+    QVImageCore imageCore { this };
 
     QTimer *expensiveScaleTimerNew;
     QPointF centerPoint;

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -468,9 +468,9 @@ void QVImageCore::addToCache(const ReadData &readData)
     qvApp->setPreviouslyRecordedImageSize(readData.fileInfo.absoluteFilePath(), new QSize(readData.size));
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
 QColorSpace QVImageCore::detectDisplayColorSpace() const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QWindow *window = static_cast<QWidget*>(parent())->window()->windowHandle();
 
     QByteArray profileData;
@@ -483,10 +483,10 @@ QColorSpace QVImageCore::detectDisplayColorSpace() const
 
     if (!profileData.isEmpty())
         return QColorSpace::fromIccProfile(profileData);
+#endif
 
     return {};
 }
-#endif
 
 void QVImageCore::jumpToNextFrame()
 {

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -14,8 +14,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 
-QCache<QString, QPixmap> QVImageCore::pixmapCache;
-QColorSpace QVImageCore::currentTargetColorSpace;
+QCache<QString, QVImageCore::ReadData> QVImageCore::pixmapCache;
 
 QVImageCore::QVImageCore(QObject *parent) : QObject(parent)
 {
@@ -102,37 +101,28 @@ void QVImageCore::loadFile(const QString &fileName)
     currentFileDetails.isLoadRequested = true;
     waitingOnLoad = true;
 
-    // Figure out target color space (and if it changed this clears cached pixmaps)
-    updateCurrentTargetColorSpace();
+    QColorSpace targetColorSpace = getTargetColorSpace();
+    QString cacheKey = getPixmapCacheKey(sanitaryFileName, fileInfo.size(), targetColorSpace);
 
     //check if cached already before loading the long way
-    auto previouslyRecordedFileSize = qvApp->getPreviouslyRecordedFileSize(sanitaryFileName);
-    auto *cachedPixmap = QVImageCore::pixmapCache.take(sanitaryFileName);
-    if (cachedPixmap != nullptr &&
-        !cachedPixmap->isNull() &&
-        previouslyRecordedFileSize == fileInfo.size())
+    auto *cachedData = QVImageCore::pixmapCache.take(cacheKey);
+    if (cachedData != nullptr)
     {
-        QSize previouslyRecordedImageSize = qvApp->getPreviouslyRecordedImageSize(sanitaryFileName);
-        ReadData readData = {
-            *cachedPixmap,
-            fileInfo,
-            previouslyRecordedImageSize,
-            currentTargetColorSpace
-        };
+        ReadData readData = *cachedData;
+        delete cachedData;
         loadPixmap(readData);
     }
     else
     {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        loadFutureWatcher.setFuture(QtConcurrent::run(this, &QVImageCore::readFile, sanitaryFileName, currentTargetColorSpace, false));
+        loadFutureWatcher.setFuture(QtConcurrent::run(this, &QVImageCore::readFile, sanitaryFileName, targetColorSpace, false));
 #else
-        loadFutureWatcher.setFuture(QtConcurrent::run(&QVImageCore::readFile, this, sanitaryFileName, currentTargetColorSpace, false));
+        loadFutureWatcher.setFuture(QtConcurrent::run(&QVImageCore::readFile, this, sanitaryFileName, targetColorSpace, false));
 #endif
     }
-    delete cachedPixmap;
 }
 
-QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColorSpace targetColorSpace, bool forCache)
+QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColorSpace &targetColorSpace, bool forCache)
 {
     QImageReader imageReader;
     imageReader.setDecideFormatFromContent(true);
@@ -167,17 +157,19 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
 #endif
 
     QPixmap readPixmap = QPixmap::fromImage(readImage);
+    QFileInfo fileInfo(fileName);
 
     ReadData readData = {
         readPixmap,
-        QFileInfo(fileName),
+        fileInfo.absoluteFilePath(),
+        fileInfo.size(),
         imageReader.size(),
         targetColorSpace
     };
     // Only error out when not loading for cache
     if (readPixmap.isNull() && !forCache)
     {
-        emit readError(imageReader.error(), imageReader.errorString(), readData.fileInfo.fileName());
+        emit readError(imageReader.error(), imageReader.errorString(), fileInfo.fileName());
     }
 
     return readData;
@@ -186,7 +178,7 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
 void QVImageCore::loadPixmap(const ReadData &readData)
 {
     // Do this first so we can keep folder info even when loading errored files
-    currentFileDetails.fileInfo = readData.fileInfo;
+    currentFileDetails.fileInfo = QFileInfo(readData.absoluteFilePath);
     currentFileDetails.updateLoadedIndexInFolder();
     if (currentFileDetails.loadedIndexInFolder == -1)
         updateFolderInfo();
@@ -201,7 +193,7 @@ void QVImageCore::loadPixmap(const ReadData &readData)
 
     // Set file details
     currentFileDetails.isPixmapLoaded = true;
-    currentFileDetails.baseImageSize = readData.size;
+    currentFileDetails.baseImageSize = readData.imageSize;
     currentFileDetails.loadedPixmapSize = loadedPixmap.size();
     if (currentFileDetails.baseImageSize == QSize(-1, -1))
     {
@@ -395,8 +387,7 @@ void QVImageCore::requestCaching()
         return;
     }
 
-    // Figure out target color space (and if it changed this clears cached pixmaps)
-    updateCurrentTargetColorSpace();
+    QColorSpace targetColorSpace = getTargetColorSpace();
 
     int preloadingDistance = 1;
 
@@ -429,19 +420,21 @@ void QVImageCore::requestCaching()
         QString filePath = currentFileDetails.folderFileInfoList[index].absoluteFilePath;
         filesToPreload.append(filePath);
 
-        requestCachingFile(filePath);
+        requestCachingFile(filePath, targetColorSpace);
     }
     lastFilesPreloaded = filesToPreload;
 
 }
 
-void QVImageCore::requestCachingFile(const QString &filePath)
+void QVImageCore::requestCachingFile(const QString &filePath, const QColorSpace &targetColorSpace)
 {
+    QFile imgFile(filePath);
+    QString cacheKey = getPixmapCacheKey(filePath, imgFile.size(), targetColorSpace);
+
     //check if image is already loaded or requested
-    if (QVImageCore::pixmapCache.contains(filePath) || lastFilesPreloaded.contains(filePath))
+    if (QVImageCore::pixmapCache.contains(cacheKey) || lastFilesPreloaded.contains(filePath))
         return;
 
-    QFile imgFile(filePath);
     if (imgFile.size()/1024 > QVImageCore::pixmapCache.maxCost()/2)
         return;
 
@@ -452,39 +445,42 @@ void QVImageCore::requestCachingFile(const QString &filePath)
     });
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    cacheFutureWatcher->setFuture(QtConcurrent::run(this, &QVImageCore::readFile, filePath, currentTargetColorSpace, true));
+    cacheFutureWatcher->setFuture(QtConcurrent::run(this, &QVImageCore::readFile, filePath, targetColorSpace, true));
 #else
-    cacheFutureWatcher->setFuture(QtConcurrent::run(&QVImageCore::readFile, this, filePath, currentTargetColorSpace, true));
+    cacheFutureWatcher->setFuture(QtConcurrent::run(&QVImageCore::readFile, this, filePath, targetColorSpace, true));
 #endif
 }
 
 void QVImageCore::addToCache(const ReadData &readData)
 {
-    if (readData.pixmap.isNull() || readData.targetColorSpace != currentTargetColorSpace)
+    if (readData.pixmap.isNull())
         return;
 
+    QString cacheKey = getPixmapCacheKey(readData.absoluteFilePath, readData.fileSize, readData.targetColorSpace);
 
-    auto fileSize = readData.fileInfo.size();
-    QVImageCore::pixmapCache.insert(readData.fileInfo.absoluteFilePath(), new QPixmap(readData.pixmap), fileSize/1024);
-
-    qvApp->setPreviouslyRecordedFileSize(readData.fileInfo.absoluteFilePath(), new qint64(fileSize));
-    qvApp->setPreviouslyRecordedImageSize(readData.fileInfo.absoluteFilePath(), new QSize(readData.size));
+    QVImageCore::pixmapCache.insert(cacheKey, new ReadData(readData), readData.fileSize/1024);
 }
 
-void QVImageCore::updateCurrentTargetColorSpace()
+QString QVImageCore::getPixmapCacheKey(const QString &absoluteFilePath, const qint64 &fileSize, const QColorSpace &targetColorSpace)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-    const QColorSpace newTargetColorSpace =
+    QString targetColorSpaceHash = QCryptographicHash::hash(targetColorSpace.iccProfile(), QCryptographicHash::Md5).toHex();
+#else
+    QString targetColorSpaceHash = "";
+#endif
+    return absoluteFilePath + "\n" + QString::number(fileSize) + "\n" + targetColorSpaceHash;
+}
+
+QColorSpace QVImageCore::getTargetColorSpace() const
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    return
         colorSpaceConversion == 1 ? detectDisplayColorSpace() :
         colorSpaceConversion == 2 ? QColorSpace::SRgb :
         colorSpaceConversion == 3 ? QColorSpace::DisplayP3 :
         QColorSpace();
-
-    if (newTargetColorSpace != currentTargetColorSpace)
-    {
-        QVImageCore::pixmapCache.clear();
-        currentTargetColorSpace = newTargetColorSpace;
-    }
+#else
+    return {};
 #endif
 }
 

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -26,6 +26,7 @@ QVImageCore::QVImageCore(QObject *parent) : QObject(parent)
     sortMode = 0;
     sortDescending = false;
     allowMimeContentDetection = false;
+    colorSpaceConversion = 0;
 
     randomSortSeed = 0;
 
@@ -133,22 +134,37 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, bool forCac
 
     imageReader.setFileName(fileName);
 
-    QPixmap readPixmap;
+    QImage readImage;
     if (imageReader.format() == "svg" || imageReader.format() == "svgz")
     {
         // Render vectors into a high resolution
         QIcon icon;
         icon.addFile(fileName);
-        readPixmap = icon.pixmap(largestDimension);
+        readImage = icon.pixmap(largestDimension).toImage();
         // If this fails, try reading the normal way so that a proper error message is given
-        if (readPixmap.isNull())
-            readPixmap = QPixmap::fromImageReader(&imageReader);
+        if (readImage.isNull())
+            readImage = imageReader.read();
     }
     else
     {
-        readPixmap = QPixmap::fromImageReader(&imageReader);
+        readImage = imageReader.read();
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    const QColorSpace defaultImageColorSpace = QColorSpace::SRgb;
+    if (!readImage.colorSpace().isValid())
+        readImage.setColorSpace(defaultImageColorSpace);
+
+    const QColorSpace targetColorSpace =
+        colorSpaceConversion == 1 ? QColorSpace::SRgb :
+        colorSpaceConversion == 2 ? QColorSpace::DisplayP3 :
+        QColorSpace();
+
+    if (targetColorSpace.isValid() && readImage.colorSpace() != targetColorSpace)
+        readImage.convertToColorSpace(targetColorSpace);
+#endif
+
+    QPixmap readPixmap = QPixmap::fromImage(readImage);
 
     ReadData readData = {
         readPixmap,
@@ -586,6 +602,23 @@ void QVImageCore::settingsUpdated()
 
     //update folder info to reflect new settings (e.g. sort order)
     updateFolderInfo();
+
+    bool changedImagePreprocessing = false;
+
+    //colorspaceconversion
+    if (colorSpaceConversion != settingsManager.getInteger("colorspaceconversion"))
+    {
+        colorSpaceConversion = settingsManager.getInteger("colorspaceconversion");
+        changedImagePreprocessing = true;
+    }
+
+    if (changedImagePreprocessing)
+    {
+        QVImageCore::pixmapCache.clear();
+
+        if (currentFileDetails.isPixmapLoaded)
+            loadFile(currentFileDetails.fileInfo.absoluteFilePath());
+    }
 }
 
 void QVImageCore::FileDetails::updateLoadedIndexInFolder()

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -28,7 +28,7 @@ QVImageCore::QVImageCore(QObject *parent) : QObject(parent)
     sortMode = 0;
     sortDescending = false;
     allowMimeContentDetection = false;
-    colorSpaceConversion = 0;
+    colorSpaceConversion = 1;
 
     randomSortSeed = 0;
 

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -2,6 +2,7 @@
 #include "qvapplication.h"
 #include "qvwin32functions.h"
 #include "qvcocoafunctions.h"
+#include "qvlinuxx11functions.h"
 #include <random>
 #include <QMessageBox>
 #include <QDir>
@@ -498,6 +499,9 @@ QColorSpace QVImageCore::detectDisplayColorSpace() const
 #endif
 #ifdef COCOA_LOADED
     profileData = QVCocoaFunctions::getIccProfileForWindow(window);
+#endif
+#ifdef X11_LOADED
+    profileData = QVLinuxX11Functions::getIccProfileForWindow(window);
 #endif
 
     if (!profileData.isEmpty())

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -63,6 +63,9 @@ public:
     void requestCaching();
     void requestCachingFile(const QString &filePath);
     void addToCache(const ReadData &readImageAndFileInfo);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QColorSpace detectDisplayColorSpace() const;
+#endif
 
     void settingsUpdated();
 

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -5,6 +5,9 @@
 #include <QImageReader>
 #include <QPixmap>
 #include <QMovie>
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+#include <QColorSpace>
+#endif
 #include <QFileInfo>
 #include <QFutureWatcher>
 #include <QTimer>
@@ -103,6 +106,7 @@ private:
     int sortMode;
     bool sortDescending;
     bool allowMimeContentDetection;
+    int colorSpaceConversion;
 
     static QCache<QString, QPixmap> pixmapCache;
 

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -53,12 +53,13 @@ public:
         QPixmap pixmap;
         QFileInfo fileInfo;
         QSize size;
+        QColorSpace targetColorSpace;
     };
 
     explicit QVImageCore(QObject *parent = nullptr);
 
     void loadFile(const QString &fileName);
-    ReadData readFile(const QString &fileName, bool forCache);
+    ReadData readFile(const QString &fileName, const QColorSpace targetColorSpace, bool forCache);
     void loadPixmap(const ReadData &readData);
     void closeImage();
     QList<CompatibleFile> getCompatibleFiles(const QString &dirPath) const;
@@ -66,6 +67,7 @@ public:
     void requestCaching();
     void requestCachingFile(const QString &filePath);
     void addToCache(const ReadData &readImageAndFileInfo);
+    void updateCurrentTargetColorSpace();
     QColorSpace detectDisplayColorSpace() const;
 
     void settingsUpdated();
@@ -113,6 +115,7 @@ private:
     int colorSpaceConversion;
 
     static QCache<QString, QPixmap> pixmapCache;
+    static QColorSpace currentTargetColorSpace;
 
     QPair<QString, qsizetype> lastDirInfo;
     unsigned randomSortSeed;

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -51,23 +51,25 @@ public:
     struct ReadData
     {
         QPixmap pixmap;
-        QFileInfo fileInfo;
-        QSize size;
+        QString absoluteFilePath;
+        qint64 fileSize;
+        QSize imageSize;
         QColorSpace targetColorSpace;
     };
 
     explicit QVImageCore(QObject *parent = nullptr);
 
     void loadFile(const QString &fileName);
-    ReadData readFile(const QString &fileName, const QColorSpace targetColorSpace, bool forCache);
+    ReadData readFile(const QString &fileName, const QColorSpace &targetColorSpace, bool forCache);
     void loadPixmap(const ReadData &readData);
     void closeImage();
     QList<CompatibleFile> getCompatibleFiles(const QString &dirPath) const;
     void updateFolderInfo(QString dirPath = QString());
     void requestCaching();
-    void requestCachingFile(const QString &filePath);
+    void requestCachingFile(const QString &filePath, const QColorSpace &targetColorSpace);
     void addToCache(const ReadData &readImageAndFileInfo);
-    void updateCurrentTargetColorSpace();
+    static QString getPixmapCacheKey(const QString &absoluteFilePath, const qint64 &fileSize, const QColorSpace &targetColorSpace);
+    QColorSpace getTargetColorSpace() const;
     QColorSpace detectDisplayColorSpace() const;
 
     void settingsUpdated();
@@ -114,8 +116,7 @@ private:
     bool allowMimeContentDetection;
     int colorSpaceConversion;
 
-    static QCache<QString, QPixmap> pixmapCache;
-    static QColorSpace currentTargetColorSpace;
+    static QCache<QString, ReadData> pixmapCache;
 
     QPair<QString, qsizetype> lastDirInfo;
     unsigned randomSortSeed;

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -5,14 +5,17 @@
 #include <QImageReader>
 #include <QPixmap>
 #include <QMovie>
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-#include <QColorSpace>
-#endif
 #include <QFileInfo>
 #include <QFutureWatcher>
 #include <QTimer>
 #include <QCache>
 #include <QElapsedTimer>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#include <QColorSpace>
+#else
+typedef QString QColorSpace;
+#endif
 
 class QVImageCore : public QObject
 {
@@ -63,9 +66,7 @@ public:
     void requestCaching();
     void requestCachingFile(const QString &filePath);
     void addToCache(const ReadData &readImageAndFileInfo);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QColorSpace detectDisplayColorSpace() const;
-#endif
 
     void settingsUpdated();
 

--- a/src/qvlinuxx11functions.cpp
+++ b/src/qvlinuxx11functions.cpp
@@ -1,0 +1,59 @@
+#include "qvlinuxx11functions.h"
+#include <QGuiApplication>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#include <QX11Info>
+#endif
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+
+namespace X11Helper
+{
+    Display* getDisplay()
+    {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        return QX11Info::display();
+#else
+        if (const auto x11App = qGuiApp->nativeInterface<QNativeInterface::QX11Application>())
+           return x11App->display();
+        return nullptr;
+#endif
+    }
+}
+
+QByteArray QVLinuxX11Functions::getIccProfileForWindow(const QWindow *window)
+{
+    Q_UNUSED(window); // Unused for now; not sure how to handle multiple monitors
+    QByteArray result;
+    Display *display = X11Helper::getDisplay();
+    if (display)
+    {
+        Atom iccProfileAtom = XInternAtom(display, "_ICC_PROFILE", True);
+        if (iccProfileAtom != None)
+        {
+            Atom type;
+            int format;
+            unsigned long size;
+            unsigned long size_left;
+            unsigned char *data;
+            int status = XGetWindowProperty(
+                display,
+                DefaultRootWindow(display),
+                iccProfileAtom,
+                0,
+                INT_MAX,
+                False,
+                XA_CARDINAL,
+                &type,
+                &format,
+                &size,
+                &size_left,
+                &data);
+            if (status == Success && data)
+            {
+                result = QByteArray(reinterpret_cast<char*>(data), size);
+                XFree(data);
+            }
+        }
+    }
+    return result;
+}

--- a/src/qvlinuxx11functions.h
+++ b/src/qvlinuxx11functions.h
@@ -1,0 +1,13 @@
+#ifndef QVLINUXX11FUNCTIONS_H
+#define QVLINUXX11FUNCTIONS_H
+
+#include <QWindow>
+
+class QVLinuxX11Functions
+{
+public:
+    static QByteArray getIccProfileForWindow(const QWindow *window);
+};
+
+#endif // QVLINUXX11FUNCTIONS_H
+

--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -57,6 +57,12 @@ QVOptionsDialog::QVOptionsDialog(QWidget *parent) :
     ui->langComboLabel->hide();
 #endif
 
+// Hide color space conversion below 5.14, which is when color space support was introduced
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
+    ui->colorSpaceConversionComboBox->hide();
+    ui->colorSpaceConversionLabel->hide();
+#endif
+
     syncSettings(false, true);
     connect(ui->langComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &QVOptionsDialog::languageComboBoxCurrentIndexChanged);
     syncShortcuts();
@@ -173,6 +179,8 @@ void QVOptionsDialog::syncSettings(bool defaults, bool makeConnections)
     syncComboBox(ui->cropModeComboBox, "cropmode", defaults, makeConnections);
     // pastactualsizeenabled
     syncCheckbox(ui->pastActualSizeCheckbox, "pastactualsizeenabled", defaults, makeConnections);
+    // colorspaceconversion
+    syncComboBox(ui->colorSpaceConversionComboBox, "colorspaceconversion", defaults, makeConnections);
     // language
     syncComboBoxData(ui->langComboBox, "language", defaults, makeConnections);
     // sortmode

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -430,6 +430,51 @@
          </property>
         </widget>
        </item>
+       <item row="10" column="1">
+        <spacer name="horizontalSpacer_9">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="colorSpaceConversionLabel">
+         <property name="text">
+          <string>Color space conversion:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QComboBox" name="colorSpaceConversionComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <item>
+          <property name="text">
+           <string>Disabled</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>sRGB</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Display P3</string>
+          </property>
+         </item>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="misc">

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -465,6 +465,11 @@
          </item>
          <item>
           <property name="text">
+           <string>Auto-detect</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>sRGB</string>
           </property>
          </item>

--- a/src/qvwin32functions.h
+++ b/src/qvwin32functions.h
@@ -14,6 +14,7 @@ public:
 
     static void showOpenWithDialog(const QString &filePath, const QWindow *parent);
 
+    static QByteArray getIccProfileForWindow(const QWindow *window);
 };
 
 #endif // QVWIN32FUNCTIONS_H

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -166,6 +166,7 @@ void SettingsManager::initializeSettingsLibrary()
     settingsLibrary.insert("cursorzoom", {true, {}});
     settingsLibrary.insert("cropmode", {0, {}});
     settingsLibrary.insert("pastactualsizeenabled", {true, {}});
+    settingsLibrary.insert("colorspaceconversion", {0, {}});
     // Miscellaneous
     settingsLibrary.insert("language", {"system", {}});
     settingsLibrary.insert("sortmode", {0, {}});

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -166,7 +166,7 @@ void SettingsManager::initializeSettingsLibrary()
     settingsLibrary.insert("cursorzoom", {true, {}});
     settingsLibrary.insert("cropmode", {0, {}});
     settingsLibrary.insert("pastactualsizeenabled", {true, {}});
-    settingsLibrary.insert("colorspaceconversion", {0, {}});
+    settingsLibrary.insert("colorspaceconversion", {1, {}});
     // Miscellaneous
     settingsLibrary.insert("language", {"system", {}});
     settingsLibrary.insert("sortmode", {0, {}});

--- a/src/src.pri
+++ b/src/src.pri
@@ -18,6 +18,7 @@ SOURCES += \
 
 macx:!CONFIG(NO_COCOA):SOURCES += $$PWD/qvcocoafunctions.mm
 win32:!CONFIG(NO_WIN32):SOURCES += $$PWD/qvwin32functions.cpp
+linux:!CONFIG(NO_X11):SOURCES += $$PWD/qvlinuxx11functions.cpp
 
 HEADERS += \
     $$PWD/mainwindow.h \
@@ -38,6 +39,7 @@ HEADERS += \
 
 macx:!CONFIG(NO_COCOA):HEADERS += $$PWD/qvcocoafunctions.h
 win32:!CONFIG(NO_WIN32):HEADERS += $$PWD/qvwin32functions.h
+linux:!CONFIG(NO_X11):HEADERS += $$PWD/qvlinuxx11functions.h
 
 FORMS += \
         $$PWD/mainwindow.ui \


### PR DESCRIPTION
Adds support for color space conversion (#283), allowing the user to pick from the following options:
<img width="293" alt="Screenshot 2023-01-15 at 5 44 44 PM" src="https://user-images.githubusercontent.com/6741660/212571177-79de4c2d-c880-4c63-b5e8-9f3425eda3d9.png">

~~As nice it would be to auto-detect the monitor's ICC profile, I don't plan on implementing that myself. Nonetheless, I think even just this first step would be appreciated by a lot of users.~~