### PR TITLE
Window matches image size when launching: fix glitch w/ maximized windows

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -459,6 +459,8 @@ void MainWindow::setWindowSize()
     if (!(windowResizeMode == 2 || (windowResizeMode == 1 && justLaunchedWithImage)))
         return;
 
+    justLaunchedWithImage = false;
+
     //check if window is maximized or fullscreened
     if (windowState() == Qt::WindowMaximized || windowState() == Qt::WindowFullScreen)
         return;
@@ -467,8 +469,6 @@ void MainWindow::setWindowSize()
     qreal minWindowResizedPercentage = qvApp->getSettingsManager().getInteger("minwindowresizedpercentage")/100.0;
     qreal maxWindowResizedPercentage = qvApp->getSettingsManager().getInteger("maxwindowresizedpercentage")/100.0;
 
-
-    justLaunchedWithImage = false;
 
     QSize imageSize = getCurrentFileDetails().loadedPixmapSize;
     imageSize -= QSize(4, 4);


### PR DESCRIPTION
If qView is starting maximized (e.g. it remembers that it was maximized before exiting the previous time), and with "Window matches image size" set to "When launching", the intent in the code is to give up and abort resizing:

```cpp
if (windowState() == Qt::WindowMaximized || windowState() == Qt::WindowFullScreen)
    return;
```
However, it returns before resetting the `justLaunchedWithImage` variable, which makes it keep retrying on subsequent images even though the program no longer just launched. If the user finally takes the window out of maximized mode, the next image load that occurs will resize the window.

This commit fixes the issue.