### PR TITLE
Workaround for slow Open Recent menu on Mac

### DIFF
--- a/src/actionmanager.cpp
+++ b/src/actionmanager.cpp
@@ -449,8 +449,20 @@ void ActionManager::updateRecentsMenu()
                 action->setIcon(QIcon::fromTheme(type.iconName(), QIcon::fromTheme(type.genericIconName())));
 #else
                 // set icons for mac/windows users
+                QFileInfo fileInfo(recent.filePath);
                 QFileIconProvider provider;
-                action->setIcon(provider.icon(QFileInfo(recent.filePath)));
+                QIcon icon = provider.icon(fileInfo);
+#ifdef Q_OS_MACOS
+                // On macOS, setIcon() can be really slow, especially if it has to ask the QIcon's engine
+                // (QAbstractFileIconEngine in this case) to generate a pixmap. This normally isn't a problem
+                // because QAbstractFileIconEngine implements caching, however, it doesn't allow caching for
+                // symbolic links or files that have the 'execute' permission present. The latter can be true
+                // when reading files from a Windows network share, for example. To avoid bad performance in
+                // these cases, we'll use a generic file icon instead.
+                if (fileInfo.isSymLink() || fileInfo.isExecutable())
+                    icon = provider.icon(QFileIconProvider::File);
+#endif
+                action->setIcon(icon);
 #endif
             }
             else


### PR DESCRIPTION
I had an issue where the Open Recent menu was updating slowly on macOS but only with certain files. After much troubleshooting, I figured out it was due to the 'execute' permission being present on these files. This happened with Windows network shares or files that came over from my OneDrive folder. This PR works around the issue, with a tradeoff: it uses a generic file icon for these files (notice how the first 3 are different):
![image](https://user-images.githubusercontent.com/6741660/200131195-085c1348-0ff7-4805-81a2-be82d67df70f.png)

In my opinion, this tradeoff is worth it to avoid slowdowns when switching through images. For reference, it was taking ~200 milliseconds originally to update the recents menu with these types of files, and this brings it down to ~5 milliseconds. This is on an M2 MacBook Air by the way.

If you believe the tradeoff isn't worth it, you may consider at least using one of the tricks from #519 where it clears out the icon first before calling `setText()`, which at least halves the update time to about ~100 milliseconds in my testing.