### PR TITLE
Fix double rotation bug when loading cached image

### DIFF
--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -96,7 +96,7 @@ void QVImageCore::loadFile(const QString &fileName)
     {
         QSize previouslyRecordedImageSize = qvApp->getPreviouslyRecordedImageSize(sanitaryFileName);
         ReadData readData = {
-            matchCurrentRotation(*cachedPixmap),
+            *cachedPixmap,
             fileInfo,
             previouslyRecordedImageSize
         };


### PR DESCRIPTION
`loadPixmap` always calls `matchCurrentRotation`, so this call I removed is redundant. This was likely an oversight in bb66570d, where some code was unified, eliminating the need for it to happen in both places.