### PR TITLE
Skip updating file listing in goToFile during rapid image switching

### DIFF
--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -423,7 +423,8 @@ void QVGraphicsView::originalSize()
 
 void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
 {
-    imageCore.updateFolderInfo();
+    if (!getCurrentFileDetails().timeSinceLoaded.isValid() || getCurrentFileDetails().timeSinceLoaded.hasExpired(3000))
+        imageCore.updateFolderInfo();
     if (getCurrentFileDetails().folderFileInfoList.isEmpty())
         return;
 

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -199,6 +199,8 @@ void QVImageCore::loadPixmap(const ReadData &readData, bool fromCache)
     else if (auto device = loadedMovie.device())
         device->close();
 
+    currentFileDetails.timeSinceLoaded.start();
+
     emit fileChanged();
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -221,7 +223,8 @@ void QVImageCore::closeImage()
         false,
         false,
         QSize(),
-        QSize()
+        QSize(),
+        QElapsedTimer()
     };
 
     emit fileChanged();

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -9,6 +9,7 @@
 #include <QFutureWatcher>
 #include <QTimer>
 #include <QCache>
+#include <QElapsedTimer>
 
 class QVImageCore : public QObject
 {
@@ -25,6 +26,7 @@ public:
         bool isMovieLoaded = false;
         QSize baseImageSize;
         QSize loadedPixmapSize;
+        QElapsedTimer timeSinceLoaded;
     };
 
     struct ReadData


### PR DESCRIPTION
After #517, the obvious next step is to avoid updating the file list so frequently if it's not necessary.  Although something like `QFileSystemWatcher` might be cool, in the interest of avoiding complexity, I came up with this rather simple idea instead. If an image has just been loaded in the last 3 seconds, skip updating the file list when switching images. This can improve performance when rapidly switching through images, without majorly impacting the ability to detect when new files have been added to the folder.