### PR TITLE
macOS: Fix disappearing application menu items

### DIFF
--- a/src/actionmanager.h
+++ b/src/actionmanager.h
@@ -76,7 +76,7 @@ public:
 
     void settingsUpdated();
 
-    QAction *cloneAction(const QString &key);
+    QAction *addCloneOfAction(QWidget *parent, const QString &key);
 
     QAction *getAction(const QString &key) const;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -78,18 +78,18 @@ MainWindow::MainWindow(QWidget *parent) :
 
     contextMenu = new QMenu(this);
 
-    contextMenu->addAction(actionManager.cloneAction("open"));
-    contextMenu->addAction(actionManager.cloneAction("openurl"));
+    actionManager.addCloneOfAction(contextMenu, "open");
+    actionManager.addCloneOfAction(contextMenu, "openurl");
     contextMenu->addMenu(actionManager.buildRecentsMenu(true, contextMenu));
     contextMenu->addMenu(actionManager.buildOpenWithMenu(contextMenu));
-    contextMenu->addAction(actionManager.cloneAction("opencontainingfolder"));
-    contextMenu->addAction(actionManager.cloneAction("showfileinfo"));
+    actionManager.addCloneOfAction(contextMenu, "opencontainingfolder");
+    actionManager.addCloneOfAction(contextMenu, "showfileinfo");
     contextMenu->addSeparator();
-    contextMenu->addAction(actionManager.cloneAction("rename"));
-    contextMenu->addAction(actionManager.cloneAction("delete"));
+    actionManager.addCloneOfAction(contextMenu, "rename");
+    actionManager.addCloneOfAction(contextMenu, "delete");
     contextMenu->addSeparator();
-    contextMenu->addAction(actionManager.cloneAction("nextfile"));
-    contextMenu->addAction(actionManager.cloneAction("previousfile"));
+    actionManager.addCloneOfAction(contextMenu, "nextfile");
+    actionManager.addCloneOfAction(contextMenu, "previousfile");
     contextMenu->addSeparator();
     contextMenu->addMenu(actionManager.buildViewMenu(true, contextMenu));
     contextMenu->addMenu(actionManager.buildToolsMenu(true, contextMenu));
@@ -117,7 +117,7 @@ MainWindow::MainWindow(QWidget *parent) :
     const auto &actionKeys = actionManager.getActionLibrary().keys();
     for (const QString &key : actionKeys)
     {
-        virtualMenu->addAction(actionManager.cloneAction(key));
+        actionManager.addCloneOfAction(virtualMenu, key);
     }
     addActions(virtualMenu->actions());
     connect(virtualMenu, &QMenu::triggered, this, [this](QAction *triggeredAction){

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -37,8 +37,8 @@ QVApplication::QVApplication(int &argc, char **argv) : QApplication(argc, argv)
     actionManager.loadRecentsList();
 
 #ifdef Q_OS_MACOS
-    dockMenu->addAction(actionManager.cloneAction("newwindow"));
-    dockMenu->addAction(actionManager.cloneAction("open"));
+    actionManager.addCloneOfAction(dockMenu, "newwindow");
+    actionManager.addCloneOfAction(dockMenu, "open");
     dockMenu->setAsDockMenu();
 #endif
 


### PR DESCRIPTION
Solves #527. I figured out it started happening after ea30c00; specifically, calling `deleteLater` on the action is what makes the menu items disappear. I'm guessing the part of Qt that manages the application menu doesn't expect actions to be deleted like that and can't handle it properly. This PR fixes it by ensuring that every menu item is parented properly so it can be automatically cleaned up by Qt when closing the associated window.

When testing, I verified that the menu items are indeed still being destroyed with some debug logging:
```cpp
connect(action, &QAction::destroyed, this, [](){ qDebug() << "action destroyed"; });
```