### PR TITLE
File navigation improvements

### DIFF
--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -518,7 +518,7 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
         return;
 
     if (shouldRetryFolderInfoUpdate)
-        imageCore.updateFolderInfo(nextImageFilePath);
+        imageCore.updateFolderInfo();
 
     loadFile(nextImageFilePath);
 }

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -506,9 +506,9 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
     if (searchDirection != 0)
     {
         const auto &fileList = getCurrentFileDetails().folderFileInfoList;
-        while (searchDirection == 1 && newIndex < fileList.size()-1 && !QFileInfo::exists(fileList.value(newIndex).absoluteFilePath))
+        while (searchDirection == 1 && newIndex < fileList.size()-1 && !QFile::exists(fileList.value(newIndex).absoluteFilePath))
             newIndex++;
-        while (searchDirection == -1 && newIndex > 0 && !QFileInfo::exists(fileList.value(newIndex).absoluteFilePath))
+        while (searchDirection == -1 && newIndex > 0 && !QFile::exists(fileList.value(newIndex).absoluteFilePath))
             newIndex--;
     }
 

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -518,7 +518,12 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
         return;
 
     if (shouldRetryFolderInfoUpdate)
-        imageCore.updateFolderInfo();
+    {
+        // If the user just deleted a file through qView, closeImage will have been called which empties
+        // currentFileDetails.fileInfo. In this case updateFolderInfo can't infer the directory from
+        // fileInfo like it normally does, so we'll explicity pass in the folder here.
+        imageCore.updateFolderInfo(QFileInfo(nextImageFilePath).path());
+    }
 
     loadFile(nextImageFilePath);
 }

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -449,7 +449,8 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
             shouldRetryFolderInfoUpdate = true;
     }
 
-    if (getCurrentFileDetails().folderFileInfoList.isEmpty())
+    const auto &fileList = getCurrentFileDetails().folderFileInfoList;
+    if (fileList.isEmpty())
         return;
 
     int newIndex = getCurrentFileDetails().loadedIndexInFolder;
@@ -472,7 +473,7 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
         if (newIndex == 0)
         {
             if (isLoopFoldersEnabled)
-                newIndex = getCurrentFileDetails().folderFileInfoList.size()-1;
+                newIndex = fileList.size()-1;
             else
                 emit cancelSlideshow();
         }
@@ -483,7 +484,7 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
     }
     case GoToFileMode::next:
     {
-        if (getCurrentFileDetails().folderFileInfoList.size()-1 == newIndex)
+        if (fileList.size()-1 == newIndex)
         {
             if (isLoopFoldersEnabled)
                 newIndex = 0;
@@ -497,7 +498,7 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
     }
     case GoToFileMode::last:
     {
-        newIndex = getCurrentFileDetails().folderFileInfoList.size()-1;
+        newIndex = fileList.size()-1;
         searchDirection = -1;
         break;
     }
@@ -505,14 +506,13 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
 
     if (searchDirection != 0)
     {
-        const auto &fileList = getCurrentFileDetails().folderFileInfoList;
         while (searchDirection == 1 && newIndex < fileList.size()-1 && !QFile::exists(fileList.value(newIndex).absoluteFilePath))
             newIndex++;
         while (searchDirection == -1 && newIndex > 0 && !QFile::exists(fileList.value(newIndex).absoluteFilePath))
             newIndex--;
     }
 
-    const QString nextImageFilePath = getCurrentFileDetails().folderFileInfoList.value(newIndex).absoluteFilePath;
+    const QString nextImageFilePath = fileList.value(newIndex).absoluteFilePath;
 
     if (!QFile::exists(nextImageFilePath) || nextImageFilePath == getCurrentFileDetails().fileInfo.absoluteFilePath())
         return;

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -441,7 +441,7 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
     if (!getCurrentFileDetails().timeSinceLoaded.isValid() || getCurrentFileDetails().timeSinceLoaded.hasExpired(3000))
     {
         // Make sure the file still exists because if it disappears from the file listing we'll lose
-        // lose track of our index within the folder. Use the static 'exists' method to avoid caching.
+        // track of our index within the folder. Use the static 'exists' method to avoid caching.
         // If we skip updating now, flag it for retry later once we locate a new file.
         if (QFile::exists(getCurrentFileDetails().fileInfo.absoluteFilePath()))
             imageCore.updateFolderInfo();

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -245,7 +245,7 @@ void QVImageCore::closeImage()
 }
 
 // All file logic, sorting, etc should be moved to a different class or file
-QList<QVImageCore::CompatibleFile> QVImageCore::getCompatibleFiles(const QString &dirPath)
+QList<QVImageCore::CompatibleFile> QVImageCore::getCompatibleFiles(const QString &dirPath) const
 {
     QList<CompatibleFile> fileList;
 
@@ -290,7 +290,7 @@ QList<QVImageCore::CompatibleFile> QVImageCore::getCompatibleFiles(const QString
     return fileList;
 }
 
-void QVImageCore::sortCompatibleFiles(QList<CompatibleFile> &fileList)
+void QVImageCore::sortCompatibleFiles(QList<CompatibleFile> &fileList) const
 {
     if (sortMode == 0) // Natural sorting
     {
@@ -350,7 +350,7 @@ void QVImageCore::sortCompatibleFiles(QList<CompatibleFile> &fileList)
     }
 }
 
-unsigned QVImageCore::getRandomSortSeed(const QString &dirPath, const int fileCount)
+unsigned QVImageCore::getRandomSortSeed(const QString &dirPath, const int fileCount) const
 {
     QString seed = QString::number(baseRandomSortSeed, 16) + dirPath + QString::number(fileCount, 16);
     QByteArray hash = QCryptographicHash::hash(seed.toUtf8(), QCryptographicHash::Md5);

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -83,8 +83,7 @@ void QVImageCore::loadFile(const QString &fileName)
 
     if (fileInfo.isDir())
     {
-        QString dummyFilePath = QDir::cleanPath(sanitaryFileName + QDir::separator() + "dummy.jpg");
-        updateFolderInfo(dummyFilePath);
+        updateFolderInfo(sanitaryFileName);
         if (currentFileDetails.folderFileInfoList.isEmpty())
             closeImage();
         else
@@ -290,18 +289,18 @@ QList<QVImageCore::CompatibleFile> QVImageCore::getCompatibleFiles(const QString
     return fileList;
 }
 
-void QVImageCore::updateFolderInfo(QString targetFilePath)
+void QVImageCore::updateFolderInfo(QString dirPath)
 {
-    if (targetFilePath.isEmpty())
+    if (dirPath.isEmpty())
     {
-        targetFilePath = currentFileDetails.fileInfo.absoluteFilePath();
+        dirPath = currentFileDetails.fileInfo.path();
 
-        // No path specified and a file is not already loaded
-        if (targetFilePath.isEmpty())
+        // No directory specified and a file is not already loaded from which we can infer one
+        if (dirPath.isEmpty())
             return;
     }
 
-    currentFileDetails.folderFileInfoList = getCompatibleFiles(QFileInfo(targetFilePath).path());
+    currentFileDetails.folderFileInfoList = getCompatibleFiles(dirPath);
 
     QPair<QString, qsizetype> dirInfo = {currentFileDetails.fileInfo.absoluteDir().path(),
                                          currentFileDetails.folderFileInfoList.count()};

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -302,7 +302,7 @@ void QVImageCore::updateFolderInfo(QString dirPath)
 
     currentFileDetails.folderFileInfoList = getCompatibleFiles(dirPath);
 
-    QPair<QString, qsizetype> dirInfo = {currentFileDetails.fileInfo.absoluteDir().path(),
+    QPair<QString, qsizetype> dirInfo = {dirPath,
                                          currentFileDetails.folderFileInfoList.count()};
     // If the current folder changed since the last image, assign a new seed for random sorting
     if (lastDirInfo != dirInfo)

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -55,9 +55,9 @@ public:
     ReadData readFile(const QString &fileName, bool forCache);
     void loadPixmap(const ReadData &readData, bool fromCache);
     void closeImage();
-    QList<CompatibleFile> getCompatibleFiles(const QString &dirPath);
-    void sortCompatibleFiles(QList<CompatibleFile> &fileList);
-    unsigned getRandomSortSeed(const QString &dirPath, const int fileCount);
+    QList<CompatibleFile> getCompatibleFiles(const QString &dirPath) const;
+    void sortCompatibleFiles(QList<CompatibleFile> &fileList) const;
+    unsigned getRandomSortSeed(const QString &dirPath, const int fileCount) const;
     void updateFolderInfo(QString targetFilePath = QString());
     void requestCaching();
     void requestCachingFile(const QString &filePath);

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -56,7 +56,7 @@ public:
     void loadPixmap(const ReadData &readData, bool fromCache);
     void closeImage();
     QList<CompatibleFile> getCompatibleFiles(const QString &dirPath) const;
-    void updateFolderInfo(QString targetFilePath = QString());
+    void updateFolderInfo(QString dirPath = QString());
     void requestCaching();
     void requestCachingFile(const QString &filePath);
     void addToCache(const ReadData &readImageAndFileInfo);

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -55,8 +55,10 @@ public:
     ReadData readFile(const QString &fileName, bool forCache);
     void loadPixmap(const ReadData &readData, bool fromCache);
     void closeImage();
-    QList<CompatibleFile> getCompatibleFiles();
-    void updateFolderInfo();
+    QList<CompatibleFile> getCompatibleFiles(const QString &dirPath);
+    void sortCompatibleFiles(QList<CompatibleFile> &fileList);
+    unsigned getRandomSortSeed(const QString &dirPath, const int fileCount);
+    void updateFolderInfo(QString targetFilePath = QString());
     void requestCaching();
     void requestCachingFile(const QString &filePath);
     void addToCache(const ReadData &readImageAndFileInfo);
@@ -104,8 +106,7 @@ private:
     bool sortDescending;
     bool allowMimeContentDetection;
 
-    QPair<QString, qsizetype> lastDirInfo;
-    unsigned randomSortSeed;
+    unsigned baseRandomSortSeed;
 
     QStringList lastFilesPreloaded;
 

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -56,8 +56,6 @@ public:
     void loadPixmap(const ReadData &readData, bool fromCache);
     void closeImage();
     QList<CompatibleFile> getCompatibleFiles(const QString &dirPath) const;
-    void sortCompatibleFiles(QList<CompatibleFile> &fileList) const;
-    unsigned getRandomSortSeed(const QString &dirPath, const int fileCount) const;
     void updateFolderInfo(QString targetFilePath = QString());
     void requestCaching();
     void requestCachingFile(const QString &filePath);
@@ -106,7 +104,8 @@ private:
     bool sortDescending;
     bool allowMimeContentDetection;
 
-    unsigned baseRandomSortSeed;
+    QPair<QString, qsizetype> lastDirInfo;
+    unsigned randomSortSeed;
 
     QStringList lastFilesPreloaded;
 


### PR DESCRIPTION
While trying to reproduce #472, I noticed it was already fixed by my previous optimization work. However, the optimizations introduced a new quirk in which the folder file count (e.g. when "Practical" titlebar text is enabled) didn't update immediately after deleting a file. I fixed that here, and also made it more robust to deleted files in general. For example, say you're viewing the 5th file in some folder, and files # 4 and 5 get deleted externally (e.g. via Finder/Explorer). Navigating to previous file now handles that gracefully and loads up file # 3.

This also adds the ability to drag a folder onto the qView window as discussed in #479. Thought I'd kill two birds with one stone, since there is some overlap in the code.
