### PR TITLE
CI: Fix nightly version in About dialog

### DIFF
--- a/ci/scripts/build.ps1
+++ b/ci/scripts/build.ps1
@@ -10,9 +10,9 @@ if ($IsWindows) {
 }
 
 if ((qmake --version -split '\n')[1][17] -eq '6') {
-    qmake QMAKE_APPLE_DEVICE_ARCHS="x86_64 arm64" $args[0] PREFIX=$Prefix DEFINES+="$env:nightlyDefines"
+    qmake QMAKE_APPLE_DEVICE_ARCHS="x86_64 arm64" $args[0] PREFIX=$Prefix DEFINES+="$env:NIGHTLYDEFINES"
 } else {
-    qmake $args[0] PREFIX=$Prefix DEFINES+="$env:nightlyDefines"
+    qmake $args[0] PREFIX=$Prefix DEFINES+="$env:NIGHTLYDEFINES"
 }
 
 

--- a/ci/scripts/build.ps1
+++ b/ci/scripts/build.ps1
@@ -10,9 +10,9 @@ if ($IsWindows) {
 }
 
 if ((qmake --version -split '\n')[1][17] -eq '6') {
-    qmake QMAKE_APPLE_DEVICE_ARCHS="x86_64 arm64" $args[0] PREFIX=$Prefix
+    qmake QMAKE_APPLE_DEVICE_ARCHS="x86_64 arm64" $args[0] PREFIX=$Prefix DEFINES+="$env:nightlyDefines"
 } else {
-    qmake $args[0] PREFIX=$Prefix
+    qmake $args[0] PREFIX=$Prefix DEFINES+="$env:nightlyDefines"
 }
 
 


### PR DESCRIPTION
Fixes the "About" dialog not indicating a nightly build as mentioned in [this comment](https://github.com/jurplel/qView/issues/476#issuecomment-1025460618).