### PR TITLE
CI: Ad-hoc sign app, fix overlapping artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,16 @@ jobs:
             qtVersion: '6.2.2'
           - runner: 'macOS-10.15'
             qtVersion: '5.12.12'
+            osSuffix: '_legacy'
             skipHardPlugins: 'true'
           - runner: 'windows-2019'
             qtVersion: '6.2.2'
             qtArch: 'win64_msvc2019_64'
+            osSuffix: '_64'
           - runner: 'windows-2019'
             qtVersion: '5.15.2'
             qtArch: 'win32_msvc2019'
+            osSuffix: '_32'
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Set environment variables
@@ -67,5 +70,5 @@ jobs:
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v3
         with:
-          name: qView${{ env.nightlyString }}-${{ runner.os }}-${{ env.buildNumString }}
+          name: qView${{ env.nightlyString }}-${{ runner.os }}${{ matrix.osSuffix }}-${{ env.buildNumString }}
           path: bin

--- a/ci/scripts/macdeploy.sh
+++ b/ci/scripts/macdeploy.sh
@@ -12,9 +12,10 @@ cd bin
 macdeployqt qView.app
 if [ $1 != "" ]; then
     mv qView.app qView-nightly-$1\.app
-    macdeployqt *.app -dmg
+    macdeployqt *.app -codesign=- -dmg
 else
     brew install create-dmg
+    codesign --sign - --deep qView.app
     create-dmg --volname "qView $VERSION" --window-size 660 400 --icon-size 160 --icon "qView.app" 180 170 --hide-extension qView.app --app-drop-link 480 170 "qView-$VERSION.dmg" "qView.app"
 fi
 


### PR DESCRIPTION
* Ad-hoc signing, fixes #542. Initially I tried the `codesign --sign` approach for both nightly and release versions, but macOS didn't like the nightly one saying it was corrupt (maybe the 2nd `macdeployqt` run changes some things and invalidates the signature?). For the release version I also noticed `create-dmg` can take a `codesign` parameter, but I didn't have much luck with it (I think it signed the .dmg but not the app inside? it didn't fix the repeated security prompts).
* I noticed after switching to GitHub Actions there are only 3 build artifacts whereas there used to be 5. I checked the Windows zip and found that it contained both 32 and 64 bit DLLs if the names differed, or files with the same name were getting overwritten. I suffixed the artifact name to fix this.