### PR TITLE
Fix "Recent" list getting randomly reset

### DIFF
--- a/src/actionmanager.cpp
+++ b/src/actionmanager.cpp
@@ -9,8 +9,13 @@
 
 ActionManager::ActionManager(QObject *parent) : QObject(parent)
 {
+    isSaveRecentsEnabled = true;
     recentsListMaxLength = 10;
     openWithMaxLength = 10;
+
+    // Connect to settings signal
+    connect(&qvApp->getSettingsManager(), &SettingsManager::settingsUpdated, this, &ActionManager::settingsUpdated);
+    settingsUpdated();
 
     initializeActionLibrary();
 
@@ -25,9 +30,6 @@ ActionManager::ActionManager(QObject *parent) : QObject(parent)
     windowMenu = new QMenu(tr("Window"));
     QVCocoaFunctions::setWindowMenu(windowMenu);
 #endif
-
-    // Connect to settings signal
-    connect(&qvApp->getSettingsManager(), &SettingsManager::settingsUpdated, this, &ActionManager::settingsUpdated);
 }
 
 ActionManager::~ActionManager()


### PR DESCRIPTION
I finally observed [the bug](https://github.com/jurplel/qView/issues/542#issuecomment-1364634814) reported by @LampPrinter where the recently opened files list isn't remembered. It's somewhat random because it was caused by an uninitialized variable (`isSaveRecentsEnabled`). This would typically happen right after launching qView with a file, and when `saveRecentsList` runs, it first calls `auditRecentsList` which clears the list if `isSaveRecentsEnabled` is `false`. Then it would save the list with only the one file it just added. Other constructors, like in `QVGraphicsView` and `QVImageCore` do a one-time direct call of `settingsUpdated()` right after they connect up the signal, to perform the initial settings load. The `ActionManager` constructor was missing this call.