### PR TITLE
macOS: Workaround for icons causing slowness in native menus

### DIFF
--- a/src/actionmanager.h
+++ b/src/actionmanager.h
@@ -126,6 +126,8 @@ public:
 
     static void actionTriggered(QAction *triggeredAction, MainWindow *relevantWindow);
 
+    static QIcon getCacheableIcon(const QString &cacheKey, const QIcon &icon);
+
     const QList<SRecent> &getRecentsList() const { return recentsList; }
 
     const QHash<QString, QAction*> &getActionLibrary() const { return actionLibrary; }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -378,16 +378,17 @@ void MainWindow::populateOpenWithMenu(const QList<OpenWith::OpenWithItem> openWi
                 auto openWithItem = openWithItems.value(i);
 
                 action->setVisible(true);
+                action->setIconVisibleInMenu(false); // Hide icon temporarily to speed up updates in certain cases
                 action->setText(openWithItem.name);
                 action->setIcon(openWithItem.icon);
                 auto data = action->data().toList();
                 data.replace(1, QVariant::fromValue(openWithItem));
                 action->setData(data);
+                action->setIconVisibleInMenu(true);
             }
             else
             {
                 action->setVisible(false);
-                action->setText(tr("Empty"));
             }
         }
     }

--- a/src/qvcocoafunctions.mm
+++ b/src/qvcocoafunctions.mm
@@ -1,3 +1,4 @@
+#include "actionmanager.h"
 #include "qvcocoafunctions.h"
 
 #include <QUrl>
@@ -186,7 +187,8 @@ QList<OpenWith::OpenWithItem> QVCocoaFunctions::getOpenWithItems(const QString &
         openWithItem.name = QString::fromNSString(appName);
 
         QFileIconProvider fiProvider;
-        openWithItem.icon = fiProvider.icon(QFileInfo(QString::fromNSString(absolutePath)));
+        QIcon icon = fiProvider.icon(QFileInfo(QString::fromNSString(absolutePath)));
+        openWithItem.icon = ActionManager::getCacheableIcon("application:" + QString::fromNSString(appId), icon);
 
         // If the program is the default program, save it to add to the beginning after sorting
         if ([appId isEqualToString:defaultApplication])


### PR DESCRIPTION
Alternative to #519 and #523. Although those work pretty well in practice, this is a more complete solution. It greatly improves performance even when the "Open With" items are not so static (i.e. when switching between images with different extensions). And it doesn't have the "Open Recent" generic icon tradeoff like the previous workaround did.