### PR TITLE
Fix "window matches image size" for short+wide or tall+narrow images

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -488,7 +488,7 @@ void MainWindow::setWindowSize()
     const QSize minWindowSize = screenSize * minWindowResizedPercentage;
     const QSize maxWindowSize = screenSize * maxWindowResizedPercentage;
 
-    if (imageSize.width() < minWindowSize.width() || imageSize.height() < minWindowSize.height())
+    if (imageSize.width() < minWindowSize.width() && imageSize.height() < minWindowSize.height())
     {
         imageSize.scale(minWindowSize, Qt::KeepAspectRatio);
     }


### PR DESCRIPTION
An image should only be considered smaller than the window size if **both** of the dimensions are smaller. Otherwise, images with one large dimension get shrunk such that the entire image fits into the minimum area.

As a test case, try this image. It's a screenshot of an unrelated code change, but if you save this .png and open it in qView you can observe the sizing issue when the "window matches image size" setting takes effect.
<img width="896" alt="wide" src="https://user-images.githubusercontent.com/6741660/210151677-71159587-2927-45dc-af3f-499d49205d9d.png">
