### PR TITLE
Fix GIF position sticking when trying to scroll with Ctrl+scroll wheel

### DIFF
--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -288,8 +288,8 @@ void QVGraphicsView::zoom(qreal scaleFactor, const QPoint &pos)
     {
         const QPointF p1mouse = mapFromScene(scenePos);
         const QPointF move = p1mouse - pos;
-        horizontalScrollBar()->setValue(move.x() + horizontalScrollBar()->value());
-        verticalScrollBar()->setValue(move.y() + verticalScrollBar()->value());
+        horizontalScrollBar()->setValue(horizontalScrollBar()->value() + (move.x() * (isRightToLeft() ? -1 : 1)));
+        verticalScrollBar()->setValue(verticalScrollBar()->value() + move.y());
         lastZoomRoundingError = mapToScene(pos) - scenePos;
     }
     else

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -136,6 +136,7 @@ private:
     qreal maxScalingTwoSize;
     QPoint lastZoomEventPos;
     QPointF lastZoomRoundingError;
+    QPointF lastScrollRoundingError;
 
     QTransform absoluteTransform;
     QTransform zoomBasis;


### PR DESCRIPTION
Fixes #478. Only happened when "Image scaling" was enabled, because that resets the transform and reapplies parts of it such as mirroring and flipping. It's not reapplying translations though, hence the bug. But we can use the scrollbars instead, to match what happens when the image is panned around by clicking and dragging in the viewport.

The other benefit of this approach is it makes the scrolling speed feel constant regardless of zoom level even if "Image scaling" is disabled, whereas before it would feel less sensitive the further the image was zoomed out.