### PR TITLE
Window sizing/positioning fixes

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -505,11 +505,13 @@ void MainWindow::setWindowSize()
         imageSize = minimumImageSize;
 #endif
 
-    // Adjust image size for fullsizecontentview on mac
+    int titlebarOverlap = 0;
 #ifdef COCOA_LOADED
-    int obscuredHeight = QVCocoaFunctions::getObscuredHeight(window()->windowHandle());
-    imageSize.setHeight(imageSize.height() + obscuredHeight);
+    // To account for fullsizecontentview on mac
+    titlebarOverlap = QVCocoaFunctions::getObscuredHeight(window()->windowHandle());
 #endif
+    if (titlebarOverlap != 0)
+        imageSize.setHeight(imageSize.height() + titlebarOverlap);
 
     if (menuBar()->isVisible())
         imageSize.setHeight(imageSize.height() + menuBar()->height());
@@ -521,12 +523,15 @@ void MainWindow::setWindowSize()
     QRect newRect = geometry();
     newRect.moveCenter(oldRect.center());
 
-    // Ensure titlebar is not above the top of the screen
-    const int titlebarHeight = QApplication::style()->pixelMetric(QStyle::PM_TitleBarHeight);
-    const int topOfScreen = currentScreen->availableGeometry().y();
-
-    if (newRect.y() < (topOfScreen + titlebarHeight))
-        newRect.setY(topOfScreen + titlebarHeight);
+    // Ensure titlebar is not above or below the available screen area
+    const QRect availableScreenRect = currentScreen->availableGeometry();
+    const int topFrameHeight = geometry().top() - frameGeometry().top();
+    const int windowMinY = availableScreenRect.top() + topFrameHeight;
+    const int windowMaxY = availableScreenRect.top() + availableScreenRect.height() - titlebarOverlap;
+    if (newRect.top() < windowMinY)
+        newRect.moveTop(windowMinY);
+    if (newRect.top() > windowMaxY)
+        newRect.moveTop(windowMaxY);
 
     setGeometry(newRect);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -43,7 +43,7 @@ public:
 
     void setJustLaunchedWithImage(bool value);
 
-    QScreen *screenAt(const QPoint &point);
+    QScreen *screenContaining(const QRect &rect);
 
     void openRecent(int i);
 


### PR DESCRIPTION
As I was reviewing and testing the `setWindowSize` code to figure out #531, I noticed and fixed the following problems (let's assume "window matches image size" is set to "when opening images"):

1. When viewing a small image with qView's window very close to the top of the screen, upon switching to a larger image, the window size expands around its center point. In order to avoid the titlebar going above the top of the screen, qView tries to move the window down but this ended up shrinking the window height as well, causing borders on the sides of the image.
2. Since QWindow's `geometry` excludes the frame area (e.g. border/titlebar), the code factors in the titlebar height when determining the minimum `y` location. However, on macOS, the titlebar does not actually extend above the content area, but rather overlaps into it, and this was causing the window to get moved lower onto the screen than necessary. Initially I was going to offset the screen's top by `titleBarHeight - obscuredHeight` to account for this, but calculating the top height of the frame with `geometry().top() - frameGeometry().top()` seemed like an interesting way of doing it as well. Furthermore, I discovered that the latter actually works better on Windows (the titlebar height alone is missing something, not just the border but some padding as well), so I went with it.
3. There was no similar code to also keep the titlebar from moving off the bottom of the screen. It didn't even matter on macOS because I guess the OS or Qt's OS-specific implementation is also guarding against this, but in Windows it was indeed possible for the window to move down too far.
4. I wanted to make sure this all worked nicely with multiple monitors so I changed my Windows desktop's dual monitor layout which is normally side by side to fake and pretend that one is below the other. I eventually proved the new code I had written was working as intended, but only after discovering and fixing it getting confused about which monitor the window was on. `screenAt` returned null if the center of the window didn't fall on a screen (i.e. if the window is more than halfway past the bottom or right edge of the bottom-most or right-most screen respectively). I changed it to figure out which screen contains the largest portion of the window.