### PR TITLE
Fix file index misdetection due to Unicode normalization issues

### DIFF
--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -590,12 +590,13 @@ void QVImageCore::settingsUpdated()
 
 void QVImageCore::FileDetails::updateLoadedIndexInFolder()
 {
-    const QString targetPath = fileInfo.absoluteFilePath();
+    const QString targetPath = fileInfo.absoluteFilePath().normalized(QString::NormalizationForm_D);
     for (int i = 0; i < folderFileInfoList.length(); i++)
     {
         // Compare absoluteFilePath first because it's way faster, but double-check with
         // QFileInfo::operator== because it respects file system case sensitivity rules
-        if (folderFileInfoList[i].absoluteFilePath.compare(targetPath, Qt::CaseInsensitive) == 0 &&
+        QString candidatePath = folderFileInfoList[i].absoluteFilePath.normalized(QString::NormalizationForm_D);
+        if (candidatePath.compare(targetPath, Qt::CaseInsensitive) == 0 &&
             QFileInfo(folderFileInfoList[i].absoluteFilePath) == fileInfo)
         {
             loadedIndexInFolder = i;


### PR DESCRIPTION
This fixes an issue I noticed in the picture/video from @Andreas0602 in #531. The file number in the titlebar was showing as "0". I believe macOS is performing Unicode normalization when it passes the path to launch qView from Finder, whereas the files fetched from `QDir::entryInfoList` don't have the normalization. This confuses the optimization in `updateLoadedIndexInFolder` that does a `QString::compare`. The filenames are considered different because it's comparing a single "ä" character versus one composed of "a" + U+0308 (Combining Diaeresis). Note that the optimization is very important because in a folder with ~15K files, if it has to check all of them with `FileInfo::operator==` alone, it's taking ~1010ms on one of my test machines. The optimization allows it to run in ~1ms. I was able to fix this by adding some `QString::normalize` calls, which doesn't add noticeable overhead if the string doesn't end up changing, or very minor overhead even if all of those files have characters that result in normalization changes (completes in ~9ms overall).