### PR TITLE
CI: Update OpenSSL download link

### DIFF
--- a/ci/scripts/windeployqt.ps1
+++ b/ci/scripts/windeployqt.ps1
@@ -5,7 +5,7 @@ param
 
 # Download and extract openssl
 $ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1q.zip -O openssl.zip
+Invoke-WebRequest https://www.firedaemon.com/download-firedaemon-openssl-1-zip -O openssl.zip
 7z x -y .\openssl.zip
 
 # Check if "arch" environment variable is win32


### PR DESCRIPTION
The mirror subdomain on FireDaemon isn't working anymore. Their website has a couple pages with download links:

1. [This page](https://kb.firedaemon.com/support/solutions/articles/4000121705-openssl-3-0-and-1-1-1-binary-distributions-for-microsoft-windows) links to https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-1.1.1s.zip
2. [This page](https://www.firedaemon.com/download-firedaemon-openssl) links to https://www.firedaemon.com/download-firedaemon-openssl-1-zip

Either link works from the build script so I figured 2 would be fine since it points to the latest version and won't need to be updated when they take down older versions.