### PR TITLE
Fix cache using more memory than intended

### DIFF
--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -441,11 +441,10 @@ void QVImageCore::addToCache(const ReadData &readData)
     if (readData.pixmap.isNull())
         return;
 
+    auto pixmapMemoryBytes = static_cast<qint64>(readData.pixmap.width()) * readData.pixmap.height() * readData.pixmap.depth() / 8;
+    QVImageCore::pixmapCache.insert(readData.fileInfo.absoluteFilePath(), new QPixmap(readData.pixmap), qMax(pixmapMemoryBytes / 1024, 1LL));
 
-    auto fileSize = readData.fileInfo.size();
-    QVImageCore::pixmapCache.insert(readData.fileInfo.absoluteFilePath(), new QPixmap(readData.pixmap), fileSize/1024);
-
-    qvApp->setPreviouslyRecordedFileSize(readData.fileInfo.absoluteFilePath(), new qint64(fileSize));
+    qvApp->setPreviouslyRecordedFileSize(readData.fileInfo.absoluteFilePath(), new qint64(readData.fileInfo.size()));
     qvApp->setPreviouslyRecordedImageSize(readData.fileInfo.absoluteFilePath(), new QSize(readData.size));
 }
 


### PR DESCRIPTION
In the latest nightly build, with preloading set to Adjacent, I cycled through a bunch of .jpgs and got memory usage up to ~7GB.
![image](https://user-images.githubusercontent.com/6741660/214480135-e0f36b22-d4be-400c-bc76-3e8dee67bf51.png)

With preloading set to Extended, it went over 20GB before I had to stop.
![image](https://user-images.githubusercontent.com/6741660/214480302-0df05173-3dc3-442b-b72c-ab04fb0b9a03.png)

This PR fixes the cache cost which was based on file size on disk, but pixmaps take up quite a bit more memory of course since they're uncompressed. I referenced [QPixmapCache's code](https://github.com/qt/qtbase/blob/dev/src/gui/image/qpixmapcache.cpp#L60) to make sure the logic is correct.

Build failure related to #563.