### PR TITLE
Fix window getting unmaximized/resized when exiting full screen mode.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1084,7 +1084,6 @@ void MainWindow::toggleFullScreen()
     if (windowState() == Qt::WindowFullScreen)
     {
         setWindowState(storedWindowState);
-        setWindowSize();
     }
     else
     {


### PR DESCRIPTION
This occurred with "window matches image size" set to "when opening images". Fixes #453.