### PR TITLE
Add run command functionality

### DIFF
--- a/src/actionmanager.cpp
+++ b/src/actionmanager.cpp
@@ -274,6 +274,8 @@ QMenu *ActionManager::buildToolsMenu(bool addIcon, QWidget *parent)
     if (addIcon)
         toolsMenu->setIcon(QIcon::fromTheme("configure", QIcon::fromTheme("preferences-other")));
 
+    addCloneOfAction(toolsMenu, "runcommand");
+    toolsMenu->addSeparator();
     addCloneOfAction(toolsMenu, "saveframeas");
     addCloneOfAction(toolsMenu, "pause");
     addCloneOfAction(toolsMenu, "nextframe");
@@ -596,6 +598,8 @@ void ActionManager::actionTriggered(QAction *triggeredAction, MainWindow *releva
         relevantWindow->askDeleteFile();
     } else if (key == "undo") {
         relevantWindow->undoDelete();
+    } else if (key == "runcommand") {
+        relevantWindow->runCommand();
     } else if (key == "copy") {
         relevantWindow->copy();
     } else if (key == "paste") {
@@ -769,6 +773,10 @@ void ActionManager::initializeActionLibrary()
     auto *saveFrameAsAction = new QAction(QIcon::fromTheme("document-save-as"), tr("Save Frame &As..."));
     saveFrameAsAction->setData({"gifdisable"});
     actionLibrary.insert("saveframeas", saveFrameAsAction);
+
+    auto *runCommandAction = new QAction(QIcon::fromTheme("system-run"), tr("Run &Command"));
+    runCommandAction->setData({"disable"});
+    actionLibrary.insert("runcommand", runCommandAction);
 
     auto *pauseAction = new QAction(QIcon::fromTheme("media-playback-pause"), tr("Pa&use"));
     pauseAction->setData({"gifdisable"});

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -67,6 +67,8 @@ public:
 
     void undoDelete();
 
+    void runCommand();
+
     void copy();
 
     void paste();

--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -196,6 +196,22 @@ void QVOptionsDialog::syncSettings(bool defaults, bool makeConnections)
     syncCheckbox(ui->saveRecentsCheckbox, "saverecents", defaults, makeConnections);
     // updatenotifications
     syncCheckbox(ui->updateCheckbox, "updatenotifications", defaults, makeConnections);
+    // commandstring
+    syncLineEdit(ui->commandStringLineEdit, "commandstring", defaults, makeConnections);
+}
+
+void QVOptionsDialog::syncLineEdit(QLineEdit *lineEdit, const QString &key, bool defaults, bool makeConnection)
+{
+    auto val = qvApp->getSettingsManager().getString(key, defaults);
+    lineEdit->setText(val);
+    transientSettings.insert(key, val);
+
+    if (makeConnection)
+    {
+        connect(lineEdit, &QLineEdit::textEdited, this, [this, key]() {
+            modifySetting(key, this->ui->commandStringLineEdit->text());
+        });
+    }
 }
 
 void QVOptionsDialog::syncCheckbox(QCheckBox *checkbox, const QString &key, bool defaults, bool makeConnection)

--- a/src/qvoptionsdialog.h
+++ b/src/qvoptionsdialog.h
@@ -29,6 +29,7 @@ protected:
     void modifySetting(QString key, QVariant value);
     void saveSettings();
     void syncSettings(bool defaults = false, bool makeConnections = false);
+    void syncLineEdit(QLineEdit *lineEdit, const QString &key, bool defaults = false, bool makeConnection = false);
     void syncCheckbox(QCheckBox *checkbox, const QString &key, bool defaults = false, bool makeConnection = false);
     void syncRadioButtons(QList<QRadioButton*> buttons, const QString &key, bool defaults = false, bool makeConnection = false);
     void syncComboBox(QComboBox *comboBox, const QString &key, bool defaults = false, bool makeConnection = false);

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -743,13 +743,6 @@
          </item>
         </widget>
        </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>After deletion:</string>
-         </property>
-        </widget>
-       </item>
        <item row="12" column="1">
         <widget class="QCheckBox" name="askDeleteCheckbox">
          <property name="text">
@@ -769,6 +762,46 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>After deletion:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1">
+        <spacer name="horizontalSpacer_10">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="18" column="1">
+        <widget class="QLineEdit" name="commandStringLineEdit"/>
+       </item>
+       <item row="18" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>Quick command:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="1">
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>When the &quot;Run Command&quot; action is triggered, this string is executed as a command where each occurence of %QVIEW_PATH% is replaced by the path to the currently opened image.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -855,8 +888,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>325</x>
-     <y>332</y>
+     <x>334</x>
+     <y>548</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -871,8 +904,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>257</x>
-     <y>332</y>
+     <x>266</x>
+     <y>548</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>497</width>
-    <height>558</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
       <enum>Qt::NoFocus</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="window">
       <property name="layoutDirection">
@@ -490,6 +490,91 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="fileOperations">
+      <attribute name="title">
+       <string>File Operations</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>After deletion:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="afterDeletionComboBox">
+         <property name="currentIndex">
+          <number>1</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>Move Back</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Do Nothing</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Move Forward</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="askDeleteCheckbox">
+         <property name="text">
+          <string>&amp;Ask before deleting files</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>Quick command:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLineEdit" name="commandStringLineEdit"/>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="label_11">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>When the &quot;Run Command&quot; action is triggered, this string is executed as a command where each occurence of %QVIEW_PATH% is replaced by the path to the currently opened image.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <spacer name="horizontalSpacer_8">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="misc">
       <attribute name="title">
        <string>Miscellaneous</string>
@@ -697,7 +782,7 @@
          </property>
         </spacer>
        </item>
-       <item row="14" column="1">
+       <item row="11" column="1">
         <widget class="QCheckBox" name="mimeContentDetectionCheckbox">
          <property name="toolTip">
           <string>Detect supported files in folder even if extension isn't recognized (may be slow with larger/network folders)</string>
@@ -707,99 +792,17 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="12" column="1">
         <widget class="QCheckBox" name="saveRecentsCheckbox">
          <property name="text">
           <string>Save &amp;recent files</string>
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="13" column="1">
         <widget class="QCheckBox" name="updateCheckbox">
          <property name="text">
           <string extracomment="The notifications are for new qView releases">&amp;Update notifications on startup</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QComboBox" name="afterDeletionComboBox">
-         <property name="currentIndex">
-          <number>1</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>Move Back</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Do Nothing</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Move Forward</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="12" column="1">
-        <widget class="QCheckBox" name="askDeleteCheckbox">
-         <property name="text">
-          <string>&amp;Ask before deleting files</string>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="1">
-        <spacer name="horizontalSpacer_8">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>After deletion:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="1">
-        <spacer name="horizontalSpacer_10">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="18" column="1">
-        <widget class="QLineEdit" name="commandStringLineEdit"/>
-       </item>
-       <item row="18" column="0">
-        <widget class="QLabel" name="label_9">
-         <property name="text">
-          <string>Quick command:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="1">
-        <widget class="QLabel" name="label_11">
-         <property name="text">
-          <string>When the &quot;Run Command&quot; action is triggered, this string is executed as a command where each occurence of %QVIEW_PATH% is replaced by the path to the currently opened image.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -879,6 +882,44 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>bgColorCheckbox</tabstop>
+  <tabstop>titlebarRadioButton0</tabstop>
+  <tabstop>titlebarRadioButton1</tabstop>
+  <tabstop>titlebarRadioButton2</tabstop>
+  <tabstop>titlebarRadioButton3</tabstop>
+  <tabstop>windowResizeComboBox</tabstop>
+  <tabstop>minWindowResizeSpinBox</tabstop>
+  <tabstop>maxWindowResizeSpinBox</tabstop>
+  <tabstop>menubarCheckbox</tabstop>
+  <tabstop>detailsInFullscreen</tabstop>
+  <tabstop>darkTitlebarCheckbox</tabstop>
+  <tabstop>quitOnLastWindowCheckbox</tabstop>
+  <tabstop>filteringCheckbox</tabstop>
+  <tabstop>scalingCheckbox</tabstop>
+  <tabstop>scalingTwoCheckbox</tabstop>
+  <tabstop>scaleFactorSpinBox</tabstop>
+  <tabstop>scrollZoomsCheckbox</tabstop>
+  <tabstop>cursorZoomCheckbox</tabstop>
+  <tabstop>cropModeComboBox</tabstop>
+  <tabstop>pastActualSizeCheckbox</tabstop>
+  <tabstop>colorSpaceConversionComboBox</tabstop>
+  <tabstop>afterDeletionComboBox</tabstop>
+  <tabstop>askDeleteCheckbox</tabstop>
+  <tabstop>commandStringLineEdit</tabstop>
+  <tabstop>langComboBox</tabstop>
+  <tabstop>sortComboBox</tabstop>
+  <tabstop>descendingRadioButton0</tabstop>
+  <tabstop>descendingRadioButton1</tabstop>
+  <tabstop>preloadingComboBox</tabstop>
+  <tabstop>loopFoldersCheckbox</tabstop>
+  <tabstop>slideshowDirectionComboBox</tabstop>
+  <tabstop>slideshowTimerSpinBox</tabstop>
+  <tabstop>mimeContentDetectionCheckbox</tabstop>
+  <tabstop>saveRecentsCheckbox</tabstop>
+  <tabstop>updateCheckbox</tabstop>
+  <tabstop>shortcutsTable</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -180,4 +180,5 @@ void SettingsManager::initializeSettingsLibrary()
     settingsLibrary.insert("allowmimecontentdetection", {false, {}});
     settingsLibrary.insert("saverecents", {true, {}});
     settingsLibrary.insert("updatenotifications", {false, {}});
+    settingsLibrary.insert("commandstring", {"", {}});
 }

--- a/src/shortcutmanager.cpp
+++ b/src/shortcutmanager.cpp
@@ -72,6 +72,7 @@ void ShortcutManager::initializeShortcutsList()
 #ifdef Q_OS_WIN
     shortcutsList.last().readableName = tr("Delete");
 #endif
+    shortcutsList.append({tr("Run Command"), "runcommand", QStringList(QKeySequence(Qt::Key_F4).toString()), {}});
     shortcutsList.append({tr("First File"), "firstfile", QStringList(QKeySequence(Qt::Key_Home).toString()), {}});
     shortcutsList.append({tr("Previous File"), "previousfile", QStringList(QKeySequence(Qt::Key_Left).toString()), {}});
     shortcutsList.append({tr("Next File"), "nextfile", QStringList(QKeySequence(Qt::Key_Right).toString()), {}});


### PR DESCRIPTION
This PR adds an action that runs a user-defined command with the path to the currently opened image as an argument. Solves #579 

- A new action "Run Command" is added with keyboard shortcut setting, and a button in the "Tools" menu
- The command can be specified in settings. The path is specified as a wildcard %QVIEW_PATH% anywhere in the command (even multiple times, if the user wishes)
- A new tab in settings, "File Operations" is added. It contains the above setting and file delete settings that were moved from the Misc. tab. Adding a new tab was not my first option. Originally, I wanted to put this in the Misc. section, but it was really cluttered and big - it altered the size of the entire settings windows. There was already a relatively large number of setting in the Misc. tab, so I think this is the best option.
- Code that executes command (mainwindow.cpp function) is fully portable (only uses Qt API)
- Bonus: tab order in settings was fixed

Tested on Win 10 and Kubuntu 22.4