### PR TITLE
Add "Delete Permanently" action (i.e. delete without trash)

### DIFF
--- a/src/actionmanager.cpp
+++ b/src/actionmanager.cpp
@@ -185,7 +185,7 @@ QMenuBar *ActionManager::buildMenuBar(QWidget *parent)
     addCloneOfAction(fileMenu, "closeallwindows");
 #endif
 #ifdef COCOA_LOADED
-    QVCocoaFunctions::setAlternates(fileMenu, fileMenu->actions().length()-1, fileMenu->actions().length()-2);
+    QVCocoaFunctions::setAlternate(fileMenu, fileMenu->actions().length()-1);
 #endif
     fileMenu->addSeparator();
     fileMenu->addMenu(buildOpenWithMenu(fileMenu));
@@ -207,6 +207,10 @@ QMenuBar *ActionManager::buildMenuBar(QWidget *parent)
     addCloneOfAction(editMenu, "rename");
     editMenu->addSeparator();
     addCloneOfAction(editMenu, "delete");
+    addCloneOfAction(editMenu, "deletepermanent");
+#ifdef COCOA_LOADED
+    QVCocoaFunctions::setAlternate(editMenu, editMenu->actions().length()-1);
+#endif
 
     menuBar->addMenu(editMenu);
     // End of edit menu
@@ -594,6 +598,8 @@ void ActionManager::actionTriggered(QAction *triggeredAction, MainWindow *releva
         relevantWindow->showFileInfo();
     } else if (key == "delete") {
         relevantWindow->askDeleteFile();
+    } else if (key == "deletepermanent") {
+        relevantWindow->askDeleteFile(true);
     } else if (key == "undo") {
         relevantWindow->undoDelete();
     } else if (key == "copy") {
@@ -695,6 +701,10 @@ void ActionManager::initializeActionLibrary()
 #endif
     deleteAction->setData({"disable"});
     actionLibrary.insert("delete", deleteAction);
+
+    auto *deletePermanentAction = new QAction(QIcon::fromTheme("edit-delete"), tr("Delete Permanently"));
+    deletePermanentAction->setData({"disable"});
+    actionLibrary.insert("deletepermanent", deletePermanentAction);
 
     auto *undoAction = new QAction(QIcon::fromTheme("edit-undo"), tr("&Restore from Trash"));
 #ifdef Q_OS_WIN

--- a/src/actionmanager.cpp
+++ b/src/actionmanager.cpp
@@ -597,7 +597,7 @@ void ActionManager::actionTriggered(QAction *triggeredAction, MainWindow *releva
     } else if (key == "showfileinfo") {
         relevantWindow->showFileInfo();
     } else if (key == "delete") {
-        relevantWindow->askDeleteFile();
+        relevantWindow->askDeleteFile(false);
     } else if (key == "deletepermanent") {
         relevantWindow->askDeleteFile(true);
     } else if (key == "undo") {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,7 +59,7 @@ public:
 
     void showFileInfo();
 
-    void askDeleteFile(bool permanent = false);
+    void askDeleteFile(bool permanent);
 
     void deleteFile(bool permanent);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,9 +59,9 @@ public:
 
     void showFileInfo();
 
-    void askDeleteFile();
+    void askDeleteFile(bool permanent = false);
 
-    void deleteFile();
+    void deleteFile(bool permanent);
 
     QString deleteFileLinuxFallback(const QString &path, bool putBack);
 

--- a/src/qvcocoafunctions.h
+++ b/src/qvcocoafunctions.h
@@ -23,7 +23,7 @@ public:
 
     static void setWindowMenu(QMenu *menu);
 
-    static void setAlternates(QMenu *menu, int index0, int index1);
+    static void setAlternate(QMenu *menu, int index);
 
     static void setDockRecents(const QStringList &recentPathsList);
 

--- a/src/qvcocoafunctions.mm
+++ b/src/qvcocoafunctions.mm
@@ -133,11 +133,10 @@ void QVCocoaFunctions::setWindowMenu(QMenu *menu)
     [[NSApplication sharedApplication] setWindowsMenu:nativeMenu];
 }
 
-void QVCocoaFunctions::setAlternates(QMenu *menu, int index0, int index1)
+void QVCocoaFunctions::setAlternate(QMenu *menu, int index)
 {
     NSMenu *nativeMenu = menu->toNSMenu();
-    [[nativeMenu.itemArray objectAtIndex:index0] setAlternate:true];
-    [[nativeMenu.itemArray objectAtIndex:index1] setAlternate:true];
+    [[nativeMenu.itemArray objectAtIndex:index] setAlternate:true];
 }
 
 void QVCocoaFunctions::setDockRecents(const QStringList &recentPathsList)

--- a/src/shortcutmanager.cpp
+++ b/src/shortcutmanager.cpp
@@ -72,6 +72,11 @@ void ShortcutManager::initializeShortcutsList()
 #ifdef Q_OS_WIN
     shortcutsList.last().readableName = tr("Delete");
 #endif
+    shortcutsList.append({tr("Delete Permanently"), "deletepermanent", QStringList(QKeySequence(Qt::SHIFT | Qt::Key_Delete).toString()), {}});
+#ifdef Q_OS_MACOS
+    // cmd+option+backspace
+    shortcutsList.last().defaultShortcuts.prepend(QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_Backspace).toString());
+#endif
     shortcutsList.append({tr("First File"), "firstfile", QStringList(QKeySequence(Qt::Key_Home).toString()), {}});
     shortcutsList.append({tr("Previous File"), "previousfile", QStringList(QKeySequence(Qt::Key_Left).toString()), {}});
     shortcutsList.append({tr("Next File"), "nextfile", QStringList(QKeySequence(Qt::Key_Right).toString()), {}});


### PR DESCRIPTION
* Resolves #497 and presumably #637 (couldn't repro w/ OneDrive specifically).
* Fixes issue as shown in #637 error message where the filename part is missing.
* Cleaned up macOS `setAlternate`; Apple states _A Boolean value that marks the menu item as an alternate to the **previous** menu item_. It wasn't really hurting anything though because the previous menu item was a separator and macOS won't combine them anyway unless the assigned shortcuts differ only by the option key (I think that's how it works at least based on the testing I did).

Note that this differs a bit from your request in #497 in terms of wording/shortcut keys; I had a slightly different opinion and this is a straight cherry-pick from the way I chose to do it in my fork, but feel free to request changes or make edits as necessary.