### PR TITLE
Non modal errors

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -48,6 +48,11 @@ MainWindow::MainWindow(QWidget *parent) :
     graphicsView = new QVGraphicsView(this);
     centralWidget()->layout()->addWidget(graphicsView);
 
+    // Initialize and hide errorWidget
+    errorWidget = new QVErrorWidget(this);
+    centralWidget()->layout()->addWidget(errorWidget);
+    errorWidget->hide();
+
     // Hide fullscreen label by default
     ui->fullscreenLabel->hide();
 
@@ -314,9 +319,22 @@ void MainWindow::openRecent(int i)
 }
 
 void MainWindow::fileChanged()
-{
+{  
     populateOpenWithTimer->start();
     disableActions();
+
+    const auto errorData = getCurrentFileDetails().errorData;
+    if (errorData.hasError)
+    {
+        errorWidget->setError(errorData.errorNum, errorData.errorString, getCurrentFileDetails().fileInfo.fileName());
+        graphicsView->hide();
+        errorWidget->show();
+    }
+    else
+    {
+        graphicsView->show();
+        errorWidget->hide();
+    }
 
     if (info->isVisible())
         refreshProperties();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -437,9 +437,12 @@ void MainWindow::buildWindowTitle()
             newString = QString::number(getCurrentFileDetails().loadedIndexInFolder+1);
             newString += "/" + QString::number(getCurrentFileDetails().folderFileInfoList.count());
             newString += " - " + getCurrentFileDetails().fileInfo.fileName();
-            newString += " - "  + QString::number(getCurrentFileDetails().baseImageSize.width());
-            newString += "x" + QString::number(getCurrentFileDetails().baseImageSize.height());
-            newString += " - " + QVInfoDialog::formatBytes(getCurrentFileDetails().fileInfo.size());
+            if (!getCurrentFileDetails().errorData.hasError)
+            {
+                newString += " - "  + QString::number(getCurrentFileDetails().baseImageSize.width());
+                newString += "x" + QString::number(getCurrentFileDetails().baseImageSize.height());
+                newString += " - " + QVInfoDialog::formatBytes(getCurrentFileDetails().fileInfo.size());
+            }
             newString += " - qView";
             break;
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3,6 +3,7 @@
 #include "qvapplication.h"
 #include "qvcocoafunctions.h"
 #include "qvrenamedialog.h"
+#include "qvcontentwidget.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -44,14 +45,10 @@ MainWindow::MainWindow(QWidget *parent) :
     justLaunchedWithImage = false;
     storedWindowState = Qt::WindowNoState;
 
-    // Initialize graphicsviewkDefaultBufferAlignment
-    graphicsView = new QVGraphicsView(this);
-    centralWidget()->layout()->addWidget(graphicsView);
-
-    // Initialize and hide errorWidget
-    errorWidget = new QVErrorWidget(this);
-    centralWidget()->layout()->addWidget(errorWidget);
-    errorWidget->hide();
+    // Initialize contentWidget and graphicsView
+    auto contentWidget = new QVContentWidget();
+    centralWidget()->layout()->addWidget(contentWidget);
+    graphicsView = contentWidget->getGraphicsView();
 
     // Hide fullscreen label by default
     ui->fullscreenLabel->hide();
@@ -322,19 +319,6 @@ void MainWindow::fileChanged()
 {  
     populateOpenWithTimer->start();
     disableActions();
-
-    const auto errorData = getCurrentFileDetails().errorData;
-    if (errorData.hasError)
-    {
-        errorWidget->setError(errorData.errorNum, errorData.errorString, getCurrentFileDetails().fileInfo.fileName());
-        graphicsView->hide();
-        errorWidget->show();
-    }
-    else
-    {
-        graphicsView->show();
-        errorWidget->hide();
-    }
 
     if (info->isVisible())
         refreshProperties();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -149,7 +149,6 @@ protected slots:
 private:
     Ui::MainWindow *ui;
     QVGraphicsView *graphicsView;
-    QVErrorWidget *errorWidget;
 
     QMenu *contextMenu;
     QMenu *virtualMenu;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -4,6 +4,7 @@
 #include "qvinfodialog.h"
 #include "qvimagecore.h"
 #include "qvgraphicsview.h"
+#include "qverrorwidget.h"
 #include "openwith.h"
 
 #include <QMainWindow>
@@ -148,6 +149,7 @@ protected slots:
 private:
     Ui::MainWindow *ui;
     QVGraphicsView *graphicsView;
+    QVErrorWidget *errorWidget;
 
     QMenu *contextMenu;
     QMenu *virtualMenu;

--- a/src/qvcontentwidget.cpp
+++ b/src/qvcontentwidget.cpp
@@ -1,0 +1,59 @@
+#include "qvcontentwidget.h"
+#include "qevent.h"
+#include "qmimedata.h"
+
+QVContentWidget::QVContentWidget() {
+    graphicsView = new QVGraphicsView(this);
+    errorWidget = new QVErrorWidget(this);
+
+    addWidget(graphicsView);
+    addWidget(errorWidget);
+
+    setCurrentWidget(graphicsView);
+
+    connect(graphicsView, &QVGraphicsView::fileChanged, this, &QVContentWidget::fileChanged);
+
+    setAcceptDrops(true);
+}
+
+void QVContentWidget::dropEvent(QDropEvent *event)
+{
+    QStackedWidget::dropEvent(event);
+    graphicsView->loadMimeData(event->mimeData());
+}
+
+void QVContentWidget::dragEnterEvent(QDragEnterEvent *event)
+{
+    QStackedWidget::dragEnterEvent(event);
+    if (event->mimeData()->hasUrls())
+    {
+        event->acceptProposedAction();
+    }
+}
+
+void QVContentWidget::dragMoveEvent(QDragMoveEvent *event)
+{
+    QStackedWidget::dragMoveEvent(event);
+    event->acceptProposedAction();
+}
+
+void QVContentWidget::dragLeaveEvent(QDragLeaveEvent *event)
+{
+    QStackedWidget::dragLeaveEvent(event);
+    event->accept();
+}
+
+void QVContentWidget::fileChanged()
+{
+    const auto errorData = graphicsView->getCurrentFileDetails().errorData;
+    const auto fileName = graphicsView->getCurrentFileDetails().fileInfo.fileName();
+    if (errorData.hasError)
+    {
+        errorWidget->setError(errorData.errorNum, errorData.errorString, fileName);
+        setCurrentWidget(errorWidget);
+    }
+    else
+    {
+        setCurrentWidget(graphicsView);
+    }
+}

--- a/src/qvcontentwidget.h
+++ b/src/qvcontentwidget.h
@@ -1,0 +1,36 @@
+#ifndef QVCONTENTWIDGET_H
+#define QVCONTENTWIDGET_H
+
+#include "qverrorwidget.h"
+#include "qvgraphicsview.h"
+
+#include <QStackedWidget>
+#include <QWidget>
+
+class QVContentWidget : public QStackedWidget
+{
+    Q_OBJECT
+public:
+    QVContentWidget();
+
+    QVGraphicsView *getGraphicsView() { return graphicsView; }
+    QVErrorWidget *getErrorWidget() { return errorWidget; }
+
+protected:
+    void dropEvent(QDropEvent *event) override;
+
+    void dragEnterEvent(QDragEnterEvent *event) override;
+
+    void dragMoveEvent(QDragMoveEvent *event) override;
+
+    void dragLeaveEvent(QDragLeaveEvent *event) override;
+
+private slots:
+    void fileChanged();
+
+private:
+    QVGraphicsView *graphicsView;
+    QVErrorWidget *errorWidget;
+};
+
+#endif // QVCONTENTWIDGET_H

--- a/src/qverrorwidget.cpp
+++ b/src/qverrorwidget.cpp
@@ -1,0 +1,80 @@
+#include "qvapplication.h"
+#include "qverrorwidget.h"
+#include "ui_qverrorwidget.h"
+
+QVErrorWidget::QVErrorWidget(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::QVErrorWidget)
+{
+    ui->setupUi(this);
+
+    setAutoFillBackground(true);
+
+    // Connect to settings signal
+    connect(&qvApp->getSettingsManager(), &SettingsManager::settingsUpdated, this, &QVErrorWidget::settingsUpdated);
+    settingsUpdated();
+}
+
+QVErrorWidget::~QVErrorWidget()
+{
+    delete ui;
+}
+
+void QVErrorWidget::setError(int errorNum, const QString &errorString, const QString &fileName)
+{
+    auto errorMessage = QStringList
+    {
+        tr("Error occurred opening"),
+        fileName,
+        tr("%1 (Error %2)").arg(errorString).arg(errorNum)
+    };
+    ui->errorMessageLabel->setText(errorMessage.join("\n"));
+}
+
+void QVErrorWidget::settingsUpdated()
+{
+    updateBackgroundColor();
+    updateTextColor();
+}
+
+void QVErrorWidget::updateBackgroundColor()
+{
+    auto &settingsManager = qvApp->getSettingsManager();
+
+    QBrush newBrush;
+    if (!settingsManager.getBoolean("bgcolorenabled"))
+    {
+        newBrush.setStyle(Qt::NoBrush);
+    }
+    else
+    {
+        newBrush.setStyle(Qt::SolidPattern);
+        newBrush.setColor(QColor(settingsManager.getString("bgcolor")));
+    }
+
+    auto newPalette = palette();
+    newPalette.setBrush(QPalette::Window, newBrush);
+    setPalette(newPalette);
+}
+
+void QVErrorWidget::updateTextColor()
+{
+    auto &settingsManager = qvApp->getSettingsManager();
+
+    const auto bgColor = QColor(settingsManager.getString("bgcolor"));
+    double bgLuminance = (0.299 * bgColor.red() + 0.587 * bgColor.green() + 0.114 * bgColor.blue())/255;
+
+    QColor newColor;
+    if (bgLuminance > 0.5 || !settingsManager.getBoolean("bgcolorenabled"))
+    {
+        newColor.setRgb(32, 32, 32);
+    }
+    else
+    {
+        newColor.setRgb(223, 223, 223);
+    }
+
+    auto newPalette = palette();
+    newPalette.setBrush(QPalette::WindowText, newColor);
+    setPalette(newPalette);
+}

--- a/src/qverrorwidget.h
+++ b/src/qverrorwidget.h
@@ -1,0 +1,30 @@
+#ifndef QVERRORWIDGET_H
+#define QVERRORWIDGET_H
+
+#include <QWidget>
+
+namespace Ui {
+class QVErrorWidget;
+}
+
+class QVErrorWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit QVErrorWidget(QWidget *parent = nullptr);
+    ~QVErrorWidget();
+
+    void setError(int errorNum, const QString &errorString, const QString &fileName);
+
+public slots:
+    void settingsUpdated();
+
+private:
+    Ui::QVErrorWidget *ui;
+
+    void updateBackgroundColor();
+    void updateTextColor();
+};
+
+#endif // QVERRORWIDGET_H

--- a/src/qverrorwidget.ui
+++ b/src/qverrorwidget.ui
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QVErrorWidget</class>
+ <widget class="QWidget" name="QVErrorWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="errorMessageLabel">
+     <property name="text">
+      <string>Sample text.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qverrorwidget.ui
+++ b/src/qverrorwidget.ui
@@ -21,13 +21,44 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="errorMessageLabel">
-     <property name="text">
-      <string>Sample text.</string>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+     <widget class="QLabel" name="errorMessageLabel">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>378</width>
+        <height>278</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>Sample text.</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -686,14 +686,14 @@ void QVGraphicsView::settingsUpdated()
 
     //bgcolor
     QBrush newBrush;
-    newBrush.setStyle(Qt::SolidPattern);
     if (!settingsManager.getBoolean("bgcolorenabled"))
     {
-        newBrush.setColor(QColor(0, 0, 0, 0));
+        newBrush.setStyle(Qt::NoBrush);
     }
     else
     {
         QColor newColor;
+        newBrush.setStyle(Qt::SolidPattern);
         newColor.setNamedColor(settingsManager.getString("bgcolor"));
         newBrush.setColor(newColor);
     }

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -83,29 +83,22 @@ void QVGraphicsView::resizeEvent(QResizeEvent *event)
 
 void QVGraphicsView::dropEvent(QDropEvent *event)
 {
-    QGraphicsView::dropEvent(event);
-    loadMimeData(event->mimeData());
+    event->ignore();
 }
 
 void QVGraphicsView::dragEnterEvent(QDragEnterEvent *event)
 {
-    QGraphicsView::dragEnterEvent(event);
-    if (event->mimeData()->hasUrls())
-    {
-        event->acceptProposedAction();
-    }
+    event->ignore();
 }
 
 void QVGraphicsView::dragMoveEvent(QDragMoveEvent *event)
 {
-    QGraphicsView::dragMoveEvent(event);
-    event->acceptProposedAction();
+    event->ignore();
 }
 
 void QVGraphicsView::dragLeaveEvent(QDragLeaveEvent *event)
 {
-    QGraphicsView::dragLeaveEvent(event);
-    event->accept();
+    event->ignore();
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -53,7 +53,6 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     connect(&imageCore, &QVImageCore::animatedFrameChanged, this, &QVGraphicsView::animatedFrameChanged);
     connect(&imageCore, &QVImageCore::fileChanged, this, &QVGraphicsView::postLoad);
     connect(&imageCore, &QVImageCore::updateLoadedPixmapItem, this, &QVGraphicsView::updateLoadedPixmapItem);
-    connect(&imageCore, &QVImageCore::readError, this, &QVGraphicsView::error);
 
     // Should replace the other timer eventually
     expensiveScaleTimerNew = new QTimer(this);
@@ -679,16 +678,6 @@ void QVGraphicsView::centerOn(qreal x, qreal y)
 void QVGraphicsView::centerOn(const QGraphicsItem *item)
 {
     centerOn(item->sceneBoundingRect().center());
-}
-
-void QVGraphicsView::error(int errorNum, const QString &errorString, const QString &fileName)
-{
-    if (!errorString.isEmpty())
-    {
-        closeImage();
-        QMessageBox::critical(this, tr("Error"), tr("Error occurred opening \"%3\":\n%2 (Error %1)").arg(QString::number(errorNum), errorString, fileName));
-        return;
-    }
 }
 
 void QVGraphicsView::settingsUpdated()

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -113,8 +113,6 @@ private slots:
 
     void updateLoadedPixmapItem();
 
-    void error(int errorNum, const QString &errorString, const QString &fileName);
-
 private:
 
 

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -34,6 +34,13 @@ public:
         QString mimeType;
     };
 
+    struct ErrorData
+    {
+        bool hasError;
+        int errorNum;
+        QString errorString;
+    };
+
     struct FileDetails
     {
         QFileInfo fileInfo;
@@ -46,6 +53,8 @@ public:
         QSize loadedPixmapSize;
         QElapsedTimer timeSinceLoaded;
 
+        ErrorData errorData;
+
         void updateLoadedIndexInFolder();
     };
 
@@ -56,13 +65,17 @@ public:
         qint64 fileSize;
         QSize imageSize;
         QColorSpace targetColorSpace;
+
+        ErrorData errorData;
     };
 
     explicit QVImageCore(QObject *parent = nullptr);
 
     void loadFile(const QString &fileName, bool isReloading = false);
-    ReadData readFile(const QString &fileName, const QColorSpace &targetColorSpace, bool forCache);
+    ReadData readFile(const QString &fileName, const QColorSpace &targetColorSpace);
+    void loadReadData(const ReadData &readData);
     void loadPixmap(const ReadData &readData);
+    void enterErrorState();
     void closeImage();
     QList<CompatibleFile> getCompatibleFiles(const QString &dirPath) const;
     void updateFolderInfo(QString dirPath = QString());
@@ -98,8 +111,6 @@ signals:
     void updateLoadedPixmapItem();
 
     void fileChanged();
-
-    void readError(int errorNum, const QString &errorString, const QString &fileName);
 
 private:
     QPixmap loadedPixmap;

--- a/src/src.pri
+++ b/src/src.pri
@@ -2,6 +2,7 @@ SOURCES += \
     $$PWD/main.cpp \
     $$PWD/mainwindow.cpp \
     $$PWD/openwith.cpp \
+    $$PWD/qvcontentwidget.cpp \
     $$PWD/qverrorwidget.cpp \
     $$PWD/qvgraphicsview.cpp \
     $$PWD/qvoptionsdialog.cpp \
@@ -24,6 +25,7 @@ linux:!CONFIG(NO_X11):SOURCES += $$PWD/qvlinuxx11functions.cpp
 HEADERS += \
     $$PWD/mainwindow.h \
     $$PWD/openwith.h \
+    $$PWD/qvcontentwidget.h \
     $$PWD/qverrorwidget.h \
     $$PWD/qvgraphicsview.h \
     $$PWD/qvoptionsdialog.h \

--- a/src/src.pri
+++ b/src/src.pri
@@ -2,6 +2,7 @@ SOURCES += \
     $$PWD/main.cpp \
     $$PWD/mainwindow.cpp \
     $$PWD/openwith.cpp \
+    $$PWD/qverrorwidget.cpp \
     $$PWD/qvgraphicsview.cpp \
     $$PWD/qvoptionsdialog.cpp \
     $$PWD/qvapplication.cpp \
@@ -23,6 +24,7 @@ linux:!CONFIG(NO_X11):SOURCES += $$PWD/qvlinuxx11functions.cpp
 HEADERS += \
     $$PWD/mainwindow.h \
     $$PWD/openwith.h \
+    $$PWD/qverrorwidget.h \
     $$PWD/qvgraphicsview.h \
     $$PWD/qvoptionsdialog.h \
     $$PWD/qvapplication.h \
@@ -43,6 +45,7 @@ linux:!CONFIG(NO_X11):HEADERS += $$PWD/qvlinuxx11functions.h
 
 FORMS += \
         $$PWD/mainwindow.ui \
+    $$PWD/qverrorwidget.ui \
     $$PWD/qvopenwithdialog.ui \
     $$PWD/qvoptionsdialog.ui \
     $$PWD/qvaboutdialog.ui \


### PR DESCRIPTION
This PR replaces the modal error dialog with one that is displayed directly where the image would be, without requiring the user to press enter or click on a button. Solves #387 

- The error signal/slot flow was a bit simplified. Instead of a back and forth between QVImageCore and QVGraphicsView with readError and closeImage and then emitting fileChanged, when an error is detected in QVImageCore while loading an image, fileChanged is emitted directly. The error state is saved in QVImageCore and can be checked by other components like the rest of the info about the currently loaded image by calling getCurrentFileDetails().
- To display the new error message, a new widget QVErrorWidget was added. It shows the message on a label in the middle of the widget. One interesting feature of this widget is that it has a slot connected to settingsUpdated. When it gets this signal, it sets itself a new background color to match the rest of the app. It also switches the text color of the error message to either dark or light to keep contrast with the background.
- To unify drag&drop and to avoid having to handle switching between the new QVErrorWidget and the QVGraphicsView widgets by MainWindow, QVContentWidget was created as a subclass of QStackedWidget. It is set as the content widget of the main window and by being connected to the fileChanged signal, it automatically displays the error message when appropriate. It also captures drag&drop events and tells QVGraphicsView to load a new image when it gets dropped on it.

I have tested this on Windows 10 and on Kubuntu 22.4. Below are some screenshots:

### Dark background:
![image](https://github.com/jurplel/qView/assets/66724409/11c52773-50f2-4582-9d9a-688c6f36e4e7)
![image](https://github.com/jurplel/qView/assets/66724409/bc8983f4-f599-48e3-9a5b-bc740df13f00)


### Light background:
![image](https://github.com/jurplel/qView/assets/66724409/64944241-f620-4316-aeaa-fa96bf84fb96)
![image](https://github.com/jurplel/qView/assets/66724409/620a7cab-a613-4bf0-ab66-57ed4d3760f5)
