### PR TITLE
Add config flag to disable online update check

### DIFF
--- a/qView.pro
+++ b/qView.pro
@@ -136,6 +136,15 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # Ban usage of Qt's built in foreach utility for better code style
 DEFINES += QT_NO_FOREACH
 
+# To disables both manual and automatic checking for updates either uncomment line below or
+# add config flag while building from the commad line.
+#CONFIG += qv_disable_online_version_check
+
+qv_disable_online_version_check {
+    DEFINES += QV_DISABLE_ONLINE_VERSION_CHECK
+}
+
+
 include(src/src.pri)
 
 

--- a/qView.pro
+++ b/qView.pro
@@ -138,7 +138,7 @@ DEFINES += QT_NO_FOREACH
 
 # To disables both manual and automatic checking for updates either uncomment line below or
 # add config flag while building from the commad line.
-#CONFIG += qv_disable_online_version_check
+CONFIG += qv_disable_online_version_check
 
 qv_disable_online_version_check {
     DEFINES += QV_DISABLE_ONLINE_VERSION_CHECK

--- a/src/qvaboutdialog.cpp
+++ b/src/qvaboutdialog.cpp
@@ -71,11 +71,13 @@ QVAboutDialog::QVAboutDialog(double givenLatestVersionNum, QWidget *parent) :
     ui->infoLabel2->setTextInteractionFlags(Qt::TextBrowserInteraction);
     ui->infoLabel2->setOpenExternalLinks(true);
 
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     if (latestVersionNum < 0.0)
     {
         qvApp->checkUpdates();
         latestVersionNum = 0.0;
     }
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 
     updateText();
 }
@@ -87,6 +89,7 @@ QVAboutDialog::~QVAboutDialog()
 
 void QVAboutDialog::updateText()
 {
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     QString updateText = tr("Checking for updates...");
     if (latestVersionNum > VERSION)
     {
@@ -101,8 +104,12 @@ void QVAboutDialog::updateText()
     {
         updateText = tr("Error checking for updates");
     }
+    updateText +=  + "<br>";
+#else
+    QString updateText = "";
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
     ui->updateLabel->setText(updateText +
-                             R"(<br><a style="color: #03A9F4; text-decoration:none;" href="https://interversehq.com/qview/">interversehq.com/qview</a>)");
+                             R"(<a style="color: #03A9F4; text-decoration:none;" href="https://interversehq.com/qview/">interversehq.com/qview</a>)");
 }
 
 double QVAboutDialog::getLatestVersionNum() const

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -14,7 +14,10 @@ QVApplication::QVApplication(int &argc, char **argv) : QApplication(argc, argv)
 
     // Connections
     connect(&actionManager, &ActionManager::recentsMenuUpdated, this, &QVApplication::recentsMenuUpdated);
-    connect(&updateChecker, &UpdateChecker::checkedUpdates, this, &QVApplication::checkedUpdates);
+
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
+connect(&updateChecker, &UpdateChecker::checkedUpdates, this, &QVApplication::checkedUpdates);
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 
     // Add fallback fromTheme icon search on linux with qt >5.11
 #if defined Q_OS_UNIX && !defined Q_OS_MACOS && QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
@@ -23,10 +26,12 @@ QVApplication::QVApplication(int &argc, char **argv) : QApplication(argc, argv)
 
     defineFilterLists();
 
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     // Check for updates
     // TODO: move this to after first window show event
     if (getSettingsManager().getBoolean("updatenotifications"))
         checkUpdates();
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 
     // Setup macOS dock menu
     dockMenu = new QMenu();
@@ -192,6 +197,7 @@ MainWindow *QVApplication::getMainWindow(bool shouldBeEmpty)
     return window;
 }
 
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
 void QVApplication::checkUpdates()
 {
     updateChecker.check();
@@ -209,6 +215,7 @@ void QVApplication::checkedUpdates()
         updateChecker.openDialog();
     }
 }
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 
 void QVApplication::recentsMenuUpdated()
 {
@@ -295,7 +302,11 @@ void QVApplication::openAboutDialog(QWidget *parent)
         return;
     }
 
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     aboutDialog = new QVAboutDialog(updateChecker.getLatestVersionNum(), parent);
+#else
+    aboutDialog = new QVAboutDialog(-1, parent);
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
     aboutDialog->show();
 }
 

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -16,7 +16,7 @@ QVApplication::QVApplication(int &argc, char **argv) : QApplication(argc, argv)
     connect(&actionManager, &ActionManager::recentsMenuUpdated, this, &QVApplication::recentsMenuUpdated);
 
 #ifndef QV_DISABLE_ONLINE_VERSION_CHECK
-connect(&updateChecker, &UpdateChecker::checkedUpdates, this, &QVApplication::checkedUpdates);
+    connect(&updateChecker, &UpdateChecker::checkedUpdates, this, &QVApplication::checkedUpdates);
 #endif //QV_DISABLE_ONLINE_VERSION_CHECK
 
     // Add fallback fromTheme icon search on linux with qt >5.11
@@ -26,16 +26,15 @@ connect(&updateChecker, &UpdateChecker::checkedUpdates, this, &QVApplication::ch
 
     defineFilterLists();
 
-#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     // Check for updates
     // TODO: move this to after first window show event
-    if (getSettingsManager().getBoolean("updatenotifications"))
+    if (getSettingsManager().getBoolean("updatenotifications")) {
         checkUpdates();
-#endif //QV_DISABLE_ONLINE_VERSION_CHECK
+    }
 
     // Setup macOS dock menu
     dockMenu = new QMenu();
-    connect(dockMenu, &QMenu::triggered, this, [](QAction *triggeredAction){
+    connect(dockMenu, &QMenu::triggered, this, [](QAction *triggeredAction) {
        ActionManager::actionTriggered(triggeredAction);
     });
 
@@ -49,7 +48,7 @@ connect(&updateChecker, &UpdateChecker::checkedUpdates, this, &QVApplication::ch
 
     // Build menu bar
     menuBar = actionManager.buildMenuBar();
-    connect(menuBar, &QMenuBar::triggered, this, [](QAction *triggeredAction){
+    connect(menuBar, &QMenuBar::triggered, this, [](QAction *triggeredAction) {
         ActionManager::actionTriggered(triggeredAction);
     });
 
@@ -120,7 +119,7 @@ void QVApplication::pickFile(MainWindow *parent)
     if (parent)
         fileDialog->setWindowModality(Qt::WindowModal);
 
-    connect(fileDialog, &QFileDialog::filesSelected, fileDialog, [parent](const QStringList &selected){
+    connect(fileDialog, &QFileDialog::filesSelected, fileDialog, [parent](const QStringList &selected) {
         bool isFirstLoop = true;
         for (const auto &file : selected)
         {
@@ -197,14 +196,16 @@ MainWindow *QVApplication::getMainWindow(bool shouldBeEmpty)
     return window;
 }
 
-#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
 void QVApplication::checkUpdates()
 {
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     updateChecker.check();
+#endif // QV_DISABLE_ONLINE_VERSION_CHECK
 }
 
 void QVApplication::checkedUpdates()
 {
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     if (aboutDialog)
     {
         aboutDialog->setLatestVersionNum(updateChecker.getLatestVersionNum());
@@ -214,8 +215,8 @@ void QVApplication::checkedUpdates()
     {
         updateChecker.openDialog();
     }
+#endif // QV_DISABLE_ONLINE_VERSION_CHECK
 }
-#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 
 void QVApplication::recentsMenuUpdated()
 {

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -41,11 +41,9 @@ public:
 
     MainWindow *getMainWindow(bool shouldBeEmpty);
 
-#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     void checkUpdates();
 
     void checkedUpdates();
-#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 
     void recentsMenuUpdated();
 

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -41,9 +41,11 @@ public:
 
     MainWindow *getMainWindow(bool shouldBeEmpty);
 
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     void checkUpdates();
 
     void checkedUpdates();
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 
     void recentsMenuUpdated();
 
@@ -99,7 +101,9 @@ private:
     QPointer<QVWelcomeDialog> welcomeDialog;
     QPointer<QVAboutDialog> aboutDialog;
 
+#ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     UpdateChecker updateChecker;
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 };
 
 #endif // QVAPPLICATION_H

--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -43,6 +43,10 @@ QVOptionsDialog::QVOptionsDialog(QWidget *parent) :
         setWindowTitle("Preferences");
     }
 
+#ifdef QV_DISABLE_ONLINE_VERSION_CHECK
+    ui->updateCheckbox->hide();
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
+
 // Platform specific settings
 #ifdef Q_OS_MACOS
     ui->menubarCheckbox->hide();

--- a/src/qvwelcomedialog.cpp
+++ b/src/qvwelcomedialog.cpp
@@ -53,6 +53,9 @@ QVWelcomeDialog::QVWelcomeDialog(QWidget *parent) :
     ui->infoLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
     ui->infoLabel->setOpenExternalLinks(true);
 
+#ifdef QV_DISABLE_ONLINE_VERSION_CHECK
+    ui->updateCheckBox->hide();
+#else
     ui->updateCheckBox->setChecked(qvApp->getSettingsManager().getBoolean("updatenotifications"));
     connect(ui->updateCheckBox, &QCheckBox::stateChanged, qvApp, [](int state){
         QSettings settings;
@@ -60,6 +63,7 @@ QVWelcomeDialog::QVWelcomeDialog(QWidget *parent) :
         settings.setValue("updatenotifications", state > 0);
         qvApp->getSettingsManager().loadSettings();
     });
+#endif //QV_DISABLE_ONLINE_VERSION_CHECK
 }
 
 QVWelcomeDialog::~QVWelcomeDialog()

--- a/src/src.pri
+++ b/src/src.pri
@@ -13,8 +13,9 @@ SOURCES += \
     $$PWD/qvshortcutdialog.cpp \
     $$PWD/actionmanager.cpp \
     $$PWD/settingsmanager.cpp \
-    $$PWD/shortcutmanager.cpp \
-    $$PWD/updatechecker.cpp
+    $$PWD/shortcutmanager.cpp
+
+!qv_disable_online_version_check:SOURCES += $$PWD/updatechecker.cpp
 
 macx:!CONFIG(NO_COCOA):SOURCES += $$PWD/qvcocoafunctions.mm
 win32:!CONFIG(NO_WIN32):SOURCES += $$PWD/qvwin32functions.cpp
@@ -34,8 +35,10 @@ HEADERS += \
     $$PWD/qvshortcutdialog.h \
     $$PWD/actionmanager.h \
     $$PWD/settingsmanager.h \
-    $$PWD/shortcutmanager.h \
-    $$PWD/updatechecker.h
+    $$PWD/shortcutmanager.h
+
+!qv_disable_online_version_check:HEADERS += $$PWD/updatechecker.h
+
 
 macx:!CONFIG(NO_COCOA):HEADERS += $$PWD/qvcocoafunctions.h
 win32:!CONFIG(NO_WIN32):HEADERS += $$PWD/qvwin32functions.h


### PR DESCRIPTION
This PR adds a compile time flag for disabling update checks in qView as requested by #631.

Update checks are disabled either by uncommenting the line
`CONFIG += qv_disable_online_version_check`
in qView.pro or the option can also be specified when compiling from the command line like this:
`qmake "CONFIG+=qv_disable_online_version_check" ../qView/qView.pro`

When this flag is present, checking for updates is completely removed from qView because the `UpdateChecker` class source files are not included in the project. A few macros are then used to remove references and calls of `UpdateChecker`. Settings and information labels that have to do with updates are hidden as well.

When the flag is not added, the program compiles and functions without any changes.

I tested this on Windows 10 and Kubuntu 22.04.

Here are some screenshots of hidden labels and checkboxes:

![image](https://github.com/jurplel/qView/assets/66724409/9040899a-ac33-4d04-bdcc-2bbd2efe2301)

![image](https://github.com/jurplel/qView/assets/66724409/1631a187-c043-455d-9902-ec3b8e43a186)

![image](https://github.com/jurplel/qView/assets/66724409/5037d180-9a37-4c54-9d3a-8e6684470c61)
