### PR TITLE
Fix shortcut editor not considering transient values

### DIFF
--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -330,7 +330,10 @@ void QVOptionsDialog::updateShortcutsTable()
 void QVOptionsDialog::shortcutCellDoubleClicked(int row, int column)
 {
     Q_UNUSED(column)
-    auto *shortcutDialog = new QVShortcutDialog(row, this);
+    auto getTransientShortcutCallback = [this](int index) {
+        return transientShortcuts.value(index);
+    };
+    auto *shortcutDialog = new QVShortcutDialog(row, getTransientShortcutCallback, this);
     connect(shortcutDialog, &QVShortcutDialog::shortcutsListChanged, this, [this](int index, const QStringList &stringListShortcuts) {
         transientShortcuts.replace(index, stringListShortcuts);
         updateShortcutsTable();

--- a/src/qvshortcutdialog.cpp
+++ b/src/qvshortcutdialog.cpp
@@ -6,7 +6,7 @@
 
 #include <QDebug>
 
-QVShortcutDialog::QVShortcutDialog(int index, QWidget *parent) :
+QVShortcutDialog::QVShortcutDialog(int index, GetTransientShortcutCallback getTransientShortcutCallback, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::QVShortcutDialog)
 {
@@ -19,7 +19,8 @@ QVShortcutDialog::QVShortcutDialog(int index, QWidget *parent) :
 
     shortcutObject = qvApp->getShortcutManager().getShortcutsList().value(index);
     this->index = index;
-    ui->keySequenceEdit->setKeySequence(shortcutObject.shortcuts.join(", "));
+    this->getTransientShortcutCallback = getTransientShortcutCallback;
+    ui->keySequenceEdit->setKeySequence(getTransientShortcutCallback(index).join(", "));
 }
 
 QVShortcutDialog::~QVShortcutDialog()
@@ -71,9 +72,10 @@ QString QVShortcutDialog::shortcutAlreadyBound(const QKeySequence &chosenSequenc
         return "";
 
     const auto &shortcutsList = qvApp->getShortcutManager().getShortcutsList();
-    for (const auto &shortcut : shortcutsList)
+    for (int i = 0; i < shortcutsList.length(); i++)
     {
-        auto sequenceList = ShortcutManager::stringListToKeySequenceList(shortcut.shortcuts);
+        const auto &shortcut = shortcutsList.value(i);
+        const auto sequenceList = ShortcutManager::stringListToKeySequenceList(getTransientShortcutCallback(i));
 
         if (sequenceList.contains(chosenSequence) && shortcut.name != exemptShortcut)
             return shortcut.readableName;

--- a/src/qvshortcutdialog.h
+++ b/src/qvshortcutdialog.h
@@ -1,6 +1,7 @@
 #ifndef QVSHORTCUTDIALOG_H
 #define QVSHORTCUTDIALOG_H
 
+#include <functional>
 #include <QDialog>
 #include <QAbstractButton>
 #include "shortcutmanager.h"
@@ -14,7 +15,9 @@ class QVShortcutDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit QVShortcutDialog(int index, QWidget *parent = nullptr);
+    using GetTransientShortcutCallback = std::function<QStringList(int)>;
+
+    explicit QVShortcutDialog(int index, const GetTransientShortcutCallback getTransientShortcutCallback, QWidget *parent = nullptr);
     ~QVShortcutDialog() override;
 
     QString shortcutAlreadyBound(const QKeySequence &chosenSequence, const QString &exemptShortcut);
@@ -33,6 +36,7 @@ private:
 
     ShortcutManager::SShortcut shortcutObject;
     int index;
+    GetTransientShortcutCallback getTransientShortcutCallback;
 };
 
 #endif // QVSHORTCUTDIALOG_H


### PR DESCRIPTION
This PR fixed 2 issues with the shortcut editor dialog.

1. Assuming all shortcuts are set to / saved with their default values, edit the "Show File Info" shortcut, changing it from "i" to "t". Click OK only on the "Modify Shortcuts" dialog, but do not click OK/Apply on the "Settings" dialog. Now try to edit the "Show in Finder/Explorer" shortcut, setting it to "i". You'll get an error saying "i" is already bound to "Show File Info", because the validation is only looking at the saved settings.
2. Edit any shortcut, change the key binding to something else. Click OK only on the "Modify Shortcuts" dialog, but do not click OK/Apply on the "Settings" dialog. Now try to edit the same shortcut again. When the editor dialog appears, it still has the original/saved value, rather than the new changed value.