### PR TITLE
Windows: Fix rare argument parsing bug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
     // constructor. Certain characters like U+2033 (double prime) get converted differently in argv versus
     // the value Qt is comparing with (__argv). This makes Qt incorrectly think the data was changed, and
     // it skips fetching unicode arguments from the API.
+    // https://bugreports.qt.io/browse/QTBUG-125380
     parser.process(QVWin32Functions::getCommandLineArgs());
 #else
     parser.process(app);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include "qvapplication.h"
+#include "qvwin32functions.h"
 
 #include <QCommandLineParser>
 
@@ -15,7 +16,17 @@ int main(int argc, char *argv[])
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addPositionalArgument(QObject::tr("file"), QObject::tr("The file to open."));
+#if defined Q_OS_WIN && WIN32_LOADED
+    // Workaround for unicode characters getting mangled in certain cases. To support unicode arguments on
+    // Windows, QCoreApplication normally ignores argv and gets them from the Windows API instead. But this
+    // only happens if it thinks argv hasn't been modified prior to being passed into QCoreApplication's
+    // constructor. Certain characters like U+2033 (double prime) get converted differently in argv versus
+    // the value Qt is comparing with (__argv). This makes Qt incorrectly think the data was changed, and
+    // it skips fetching unicode arguments from the API.
+    parser.process(QVWin32Functions::getCommandLineArgs());
+#else
     parser.process(app);
+#endif
 
     auto *window = QVApplication::newWindow();
     if (!parser.positionalArguments().isEmpty())

--- a/src/qvwin32functions.cpp
+++ b/src/qvwin32functions.cpp
@@ -145,6 +145,22 @@ void QVWin32Functions::showOpenWithDialog(const QString &filePath, const QWindow
         qDebug() << "Failed launching open with dialog";
 }
 
+// Logic borrowed from Qt's private qWinCmdArgs function
+QStringList QVWin32Functions::getCommandLineArgs()
+{
+    const QString cmdLine = QString::fromWCharArray(GetCommandLine());
+    QStringList result;
+    int size;
+    if (wchar_t **argv = CommandLineToArgvW((const wchar_t *)cmdLine.utf16(), &size)) {
+        result.reserve(size);
+        wchar_t **argvEnd = argv + size;
+        for (wchar_t **a = argv; a < argvEnd; ++a)
+            result.append(QString::fromWCharArray(*a));
+        LocalFree(argv);
+    }
+    return result;
+}
+
 QByteArray QVWin32Functions::getIccProfileForWindow(const QWindow *window)
 {
     QByteArray result;

--- a/src/qvwin32functions.h
+++ b/src/qvwin32functions.h
@@ -14,6 +14,8 @@ public:
 
     static void showOpenWithDialog(const QString &filePath, const QWindow *parent);
 
+    static QStringList getCommandLineArgs();
+
     static QByteArray getIccProfileForWindow(const QWindow *window);
 };
 


### PR DESCRIPTION
Fixes #679. See explanation in the code comments. The bug comes from Qt's code [here](https://github.com/qt/qtbase/blob/dev/src/corelib/kernel/qcoreapplication.cpp#L397) and [here](https://github.com/qt/qtbase/blob/dev/src/entrypoint/qtentrypoint_win.cpp#L39). I borrowed [this](https://github.com/qt/qtbase/blob/dev/src/corelib/kernel/qcorecmdlineargs_p.h#L34) for the fix, which is how Qt [does it](https://github.com/qt/qtbase/blob/dev/src/corelib/kernel/qcoreapplication.cpp#L2618) if it doesn't detect "modified" arguments.

Initially I tried simply setting `argc = __argc` and `argv = __argv` at the top of `main`, which worked great on the 64-bit Qt 6 build, but it crashed the 32-bit Qt 5 build if the weird unicode character was involved.

EDIT: I reported this as [QTBUG-125380](https://bugreports.qt.io/browse/QTBUG-125380), by the way.