### PR TITLE
Image format plugin updates

### DIFF
--- a/dist/scripts/download-plugins.ps1
+++ b/dist/scripts/download-plugins.ps1
@@ -11,13 +11,12 @@ Write-Host "Detected Qt Version $qtVersion"
 if ($IsWindows) {
     $imageName = "windows-2019"
 } elseif ($IsMacOS) {
-    $imageName = "macos-latest"
+    $imageName = "macos-12"
 } else {
     $imageName = "ubuntu-20.04"
 }
 
 $binaryBaseUrl = "https://github.com/jurplel/kimageformats-binaries/releases/download/cont"
-$pluginQtVersion = If ($qtVersion -like '6.*') { "6.4.3" } Else { $qtVersion }
 
 if ($pluginNames.count -eq 0) {
     Write-Host "the pluginNames array is empty."
@@ -25,7 +24,7 @@ if ($pluginNames.count -eq 0) {
 
 foreach ($pluginName in $pluginNames) {
     $arch = If (-not $env:arch -or $env:arch -eq '') { "" } Else { "-$env:arch" }
-    $artifactName = "$pluginName-$imageName-$pluginQtVersion$arch.zip"
+    $artifactName = "$pluginName-$imageName-$qtVersion$arch.zip"
     $downloadUrl = "$binaryBaseUrl/$artifactName"
 
     Write-Host "Downloading $downloadUrl"
@@ -52,11 +51,11 @@ New-Item -Type Directory -Path "$out_imf" -ErrorAction SilentlyContinue
 # Copy QtApng
 if ($pluginNames -contains 'qtapng') {
     if ($IsWindows) {
-        cp qtapng/QtApng/plugins/imageformats/qapng.dll "$out_imf/"
+        cp qtapng/QtApng/output/qapng.dll "$out_imf/"
     } elseif ($IsMacOS) {
-        cp qtapng/QtApng/plugins/imageformats/libqapng.dylib "$out_imf/"
+        cp qtapng/QtApng/output/libqapng.* "$out_imf/"
     } else {
-        cp qtapng/QtApng/plugins/imageformats/libqapng.so "$out_imf/"
+        cp qtapng/QtApng/output/libqapng.so "$out_imf/"
     }
 }
 
@@ -76,8 +75,9 @@ if ($pluginNames -contains 'kimageformats') {
         # copy heif stuff
         if (Test-Path -Path kimageformats/kimageformats/output/heif.dll -PathType Leaf) {
             cp kimageformats/kimageformats/output/heif.dll "$out_frm/"
-            cp kimageformats/kimageformats/output/de265.dll "$out_frm/"
+            cp kimageformats/kimageformats/output/libde265.dll "$out_frm/"
             cp kimageformats/kimageformats/output/libx265.dll "$out_frm/"
+            cp kimageformats/kimageformats/output/aom.dll "$out_frm/"
         }
         # copy raw stuff
         if (Test-Path -Path kimageformats/kimageformats/output/raw.dll -PathType Leaf) {
@@ -88,19 +88,22 @@ if ($pluginNames -contains 'kimageformats') {
         # copy jxl stuff
         if (Test-Path -Path kimageformats/kimageformats/output/jxl.dll -PathType Leaf) {
             cp kimageformats/kimageformats/output/jxl.dll "$out_frm/"
+            cp kimageformats/kimageformats/output/jxl_cms.dll "$out_frm/"
             cp kimageformats/kimageformats/output/jxl_threads.dll "$out_frm/"
+            cp kimageformats/kimageformats/output/lcms2.dll "$out_frm/"
             cp kimageformats/kimageformats/output/hwy.dll "$out_frm/"
             cp kimageformats/kimageformats/output/brotlicommon.dll "$out_frm/"
             cp kimageformats/kimageformats/output/brotlidec.dll "$out_frm/"
             cp kimageformats/kimageformats/output/brotlienc.dll "$out_frm/"
         }
-        # copy jxl stuff
-        if (Test-Path -Path kimageformats/kimageformats/output/OpenEXR-3_1.dll -PathType Leaf) {
-            cp kimageformats/kimageformats/output/zlib1.dll "$out_frm/"
-            cp kimageformats/kimageformats/output/OpenEXR-3_1.dll "$out_frm/"
+        # copy openexr stuff
+        if (Test-Path -Path kimageformats/kimageformats/output/OpenEXR-3_2.dll -PathType Leaf) {
+            cp kimageformats/kimageformats/output/deflate.dll "$out_frm/"
+            cp kimageformats/kimageformats/output/OpenEXR-3_2.dll "$out_frm/"
+            cp kimageformats/kimageformats/output/OpenEXRCore-3_2.dll "$out_frm/"
             cp kimageformats/kimageformats/output/Imath-3_1.dll "$out_frm/"
-            cp kimageformats/kimageformats/output/IlmThread-3_1.dll "$out_frm/"
-            cp kimageformats/kimageformats/output/Iex-3_1.dll "$out_frm/"
+            cp kimageformats/kimageformats/output/IlmThread-3_2.dll "$out_frm/"
+            cp kimageformats/kimageformats/output/Iex-3_2.dll "$out_frm/"
         }
     } elseif ($IsMacOS) {
         cp kimageformats/kimageformats/output/*.so "$out_imf/"

--- a/dist/scripts/macdeploy.sh
+++ b/dist/scripts/macdeploy.sh
@@ -10,7 +10,15 @@ fi
 cd bin
 
 macdeployqt qView.app
+
+if [[ -f "qView.app/Contents/PlugIns/imageformats/kimg_heif.so" && -f "qView.app/Contents/PlugIns/imageformats/libqmacheif.dylib" ]]; then
+    # Prefer kimageformats HEIF plugin for proper color space handling
+    echo "Removing duplicate HEIF plugin"
+    rm "qView.app/Contents/PlugIns/imageformats/libqmacheif.dylib"
+fi
+
 codesign --sign - --deep qView.app
+
 if [ $1 != "" ]; then
     BUILD_NAME=qView-nightly-$1
     mv qView.app "$BUILD_NAME.app"


### PR DESCRIPTION
Use updated kimageformats-binaries. Noteworthy: Fixes #606. Adds [.qoi](https://qoiformat.org/) support.