### PR TITLE
Workaround for ICC profile parsing bug in Qt

### DIFF
--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -72,6 +72,7 @@ public:
     static QString getPixmapCacheKey(const QString &absoluteFilePath, const qint64 &fileSize, const QColorSpace &targetColorSpace);
     QColorSpace getTargetColorSpace() const;
     QColorSpace detectDisplayColorSpace() const;
+    static bool removeTinyDataTagsFromIccProfile(QByteArray &profile);
 
     void settingsUpdated();
 

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -72,7 +72,9 @@ public:
     static QString getPixmapCacheKey(const QString &absoluteFilePath, const qint64 &fileSize, const QColorSpace &targetColorSpace);
     QColorSpace getTargetColorSpace() const;
     QColorSpace detectDisplayColorSpace() const;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
     static bool removeTinyDataTagsFromIccProfile(QByteArray &profile);
+#endif
 
     void settingsUpdated();
 


### PR DESCRIPTION
Fixes #673. QColorSpace, even if considered invalid, preserves the original ICC profile data ([except for PNG](https://bugreports.qt.io/browse/QTBUG-125246) ☹️), which makes this possible. An oversight in Qt's ICC parser makes it require that all data chunks are at least 12 bytes, but per the ICC spec, some can be smaller, like a text field (presumably for something unimportant like a comment) with no or only a few characters. This workaround rewrites the ICC profile's table of contents to remove references to any data segments less than 12 bytes. See page 20 (labeled page 11 in the footer) of the [ICC specification](https://color.org/specification/ICC.1-2001-04.pdf) for a brief overview of the file format.