### PR TITLE
CI: Option to notarize macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ on:
         description: 'Is this a release build?'
         required: false
         default: false
+      appleNotarize:
+        type: boolean
+        description: 'Notarize with Apple?'
+        required: false
+        default: false
 jobs:
   build:
     strategy:
@@ -63,6 +68,12 @@ jobs:
         run: dist/scripts/build.ps1
 
       - name: Deploy qView
+        env:
+          APPLE_NOTARIZE_REQUESTED: ${{ inputs.appleNotarize }}
+          APPLE_DEVID_APP_CERT_DATA: ${{ secrets.APPLE_DEVID_APP_CERT_DATA }}
+          APPLE_DEVID_APP_CERT_PASS: ${{ secrets.APPLE_DEVID_APP_CERT_PASS }}
+          APPLE_ID_USER: ${{ secrets.APPLE_ID_USER }}
+          APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
         shell: pwsh
         run: |
           if ("${{ matrix.skipPlugins }}" -ne "true") {

--- a/dist/scripts/macdeploy.sh
+++ b/dist/scripts/macdeploy.sh
@@ -1,14 +1,33 @@
 #!/usr/bin/bash
 
-if [ $1 != "" ]; then
-        VERSION=$0
+if [[ -n "$1" ]]; then
+    VERSION=$0
 else
-        VERSION=$(LC_ALL=C sed -n -e '/^VERSION/p' qView.pro)
-        VERSION=${VERSION: -3}
+    VERSION=$(LC_ALL=C sed -n -e '/^VERSION/p' qView.pro)
+    VERSION=${VERSION: -3}
+fi
+
+if [[ -n "$APPLE_DEVID_APP_CERT_DATA" ]]; then
+    CODESIGN_CERT_PATH=$RUNNER_TEMP/codesign.p12
+    KEYCHAIN_PATH=$RUNNER_TEMP/codesign.keychain-db
+    KEYCHAIN_PASS=$(uuidgen)
+
+    echo -n "$APPLE_DEVID_APP_CERT_DATA" | base64 --decode -o "$CODESIGN_CERT_PATH"
+
+    security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+    security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+    security import "$CODESIGN_CERT_PATH" -P "$APPLE_DEVID_APP_CERT_PASS" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+    security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+    security list-keychains -d user -s "$KEYCHAIN_PATH"
+
+    CODESIGN_CERT_NAME=$(openssl pkcs12 -in "$CODESIGN_CERT_PATH" -passin pass:"$APPLE_DEVID_APP_CERT_PASS" -nokeys -clcerts -info 2>&1 | openssl x509 -noout -subject -nameopt multiline | grep commonName | awk -F'= ' '{print $2}')
+else
+    CODESIGN_CERT_NAME=-
 fi
 
 cd bin
 
+echo "Running macdeployqt"
 macdeployqt qView.app
 
 if [[ -f "qView.app/Contents/PlugIns/imageformats/kimg_heif.so" && -f "qView.app/Contents/PlugIns/imageformats/libqmacheif.dylib" ]]; then
@@ -17,15 +36,30 @@ if [[ -f "qView.app/Contents/PlugIns/imageformats/kimg_heif.so" && -f "qView.app
     rm "qView.app/Contents/PlugIns/imageformats/libqmacheif.dylib"
 fi
 
-codesign --sign - --deep qView.app
-
-if [ $1 != "" ]; then
-    BUILD_NAME=qView-nightly-$1
-    mv qView.app "$BUILD_NAME.app"
-    hdiutil create -volname "$BUILD_NAME" -srcfolder "$BUILD_NAME.app" -fs HFS+ "$BUILD_NAME.dmg"
+echo "Running codesign"
+if [[ "$APPLE_NOTARIZE_REQUESTED" == "true" ]]; then
+    APP_IDENTIFIER=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "qView.app/Contents/Info.plist")
+    codesign --sign "$CODESIGN_CERT_NAME" --deep --options runtime --timestamp "qView.app"
 else
+    codesign --sign "$CODESIGN_CERT_NAME" --deep "qView.app"
+fi
+
+echo "Creating disk image"
+if [[ -n "$1" ]]; then
+    BUILD_NAME=qView-nightly-$1
+    DMG_FILENAME=$BUILD_NAME.dmg
+    mv qView.app "$BUILD_NAME.app"
+    hdiutil create -volname "$BUILD_NAME" -srcfolder "$BUILD_NAME.app" -fs HFS+ "$DMG_FILENAME"
+else
+    DMG_FILENAME=qView-$VERSION.dmg
     brew install create-dmg
-    create-dmg --volname "qView $VERSION" --window-size 660 400 --icon-size 160 --icon "qView.app" 180 170 --hide-extension qView.app --app-drop-link 480 170 "qView-$VERSION.dmg" "qView.app"
+    create-dmg --volname "qView $VERSION" --window-size 660 400 --icon-size 160 --icon "qView.app" 180 170 --hide-extension qView.app --app-drop-link 480 170 "$DMG_FILENAME" "qView.app"
+fi
+if [[ "$APPLE_NOTARIZE_REQUESTED" == "true" ]]; then
+    codesign --sign "$CODESIGN_CERT_NAME" --timestamp --identifier "$APP_IDENTIFIER.dmg" "$DMG_FILENAME"
+    xcrun notarytool submit "$DMG_FILENAME" --apple-id "$APPLE_ID_USER" --password "$APPLE_ID_PASS" --team-id "${CODESIGN_CERT_NAME: -11:10}" --wait
+    xcrun stapler staple "$DMG_FILENAME"
+    xcrun stapler validate "$DMG_FILENAME"
 fi
 
 rm -r *.app


### PR DESCRIPTION
Most of it is fairly boilerplate stuff that you'll find by searching how to integrate signing/notarization into CI. Adds an input to the workflow that when checked, requires the following secrets:
APPLE_DEVID_APP_CERT_DATA: Your Developer ID Application certificate exported as P12 + base64 encoded
APPLE_DEVID_APP_CERT_PASS: The export password for that certificate
APPLE_ID_USER: Your Apple ID (i.e. email address)
APPLE_ID_PASS: Not your actual Apple password; rather an [app-specific password](https://support.apple.com/en-us/102654)

The openssl/grep/awk stuff is just some magic to detect the common name from the certificate instead of needing to have an additional pre-defined variable or secret for it.