### PR TITLE
Update check fixes/improvements

### DIFF
--- a/qView.pro
+++ b/qView.pro
@@ -137,8 +137,8 @@ DEFINES += QT_DEPRECATED_WARNINGS
 DEFINES += QT_NO_FOREACH
 
 # To disables both manual and automatic checking for updates either uncomment line below or
-# add config flag while building from the commad line.
-CONFIG += qv_disable_online_version_check
+# add config flag while building from the command line.
+#CONFIG += qv_disable_online_version_check
 
 qv_disable_online_version_check {
     DEFINES += QV_DISABLE_ONLINE_VERSION_CHECK

--- a/src/qvaboutdialog.cpp
+++ b/src/qvaboutdialog.cpp
@@ -74,7 +74,7 @@ QVAboutDialog::QVAboutDialog(double givenLatestVersionNum, QWidget *parent) :
 #ifndef QV_DISABLE_ONLINE_VERSION_CHECK
     if (latestVersionNum < 0.0)
     {
-        qvApp->checkUpdates();
+        qvApp->checkUpdates(false);
         latestVersionNum = 0.0;
     }
 #endif //QV_DISABLE_ONLINE_VERSION_CHECK

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -29,7 +29,7 @@ QVApplication::QVApplication(int &argc, char **argv) : QApplication(argc, argv)
     // Check for updates
     // TODO: move this to after first window show event
     if (getSettingsManager().getBoolean("updatenotifications")) {
-        checkUpdates();
+        checkUpdates(true);
     }
 
     // Setup macOS dock menu
@@ -196,10 +196,10 @@ MainWindow *QVApplication::getMainWindow(bool shouldBeEmpty)
     return window;
 }
 
-void QVApplication::checkUpdates()
+void QVApplication::checkUpdates(bool isStartupCheck)
 {
 #ifndef QV_DISABLE_ONLINE_VERSION_CHECK
-    updateChecker.check();
+    updateChecker.check(isStartupCheck);
 #endif // QV_DISABLE_ONLINE_VERSION_CHECK
 }
 

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -41,7 +41,7 @@ public:
 
     MainWindow *getMainWindow(bool shouldBeEmpty);
 
-    void checkUpdates();
+    void checkUpdates(bool isStartupCheck);
 
     void checkedUpdates();
 

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -16,7 +16,7 @@ UpdateChecker::UpdateChecker(QObject *parent) : QObject(parent)
 
 void UpdateChecker::check()
 {
-    sendRequest(UPDATE_URL);
+    sendRequest(UPDATE_URL + "/latest");
 }
 
 void UpdateChecker::sendRequest(const QUrl &url)
@@ -49,7 +49,7 @@ void UpdateChecker::readReply(QNetworkReply *reply)
         return;
     }
 
-    QJsonObject object = json.array().first().toObject();
+    QJsonObject object = json.object();
 
     latestVersionNum = object.value("tag_name").toString("0.0").toDouble();
 

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -9,7 +9,7 @@ class UpdateChecker : public QObject
 public:
     explicit UpdateChecker(QObject *parent = nullptr);
 
-    void check();
+    void check(bool isStartupCheck);
 
     void openDialog();
 
@@ -23,11 +23,15 @@ protected:
 
     void readReply(QNetworkReply *reply);
 
-    bool showSystemNotification();
+    QDateTime getLastCheckTime() const;
+
+    void setLastCheckTime(QDateTime value);
 
 private:
     const QString UPDATE_URL = "https://api.github.com/repos/jurplel/qview/releases";
     const QString DOWNLOAD_URL = "https://interversehq.com/qview/download/";
+    // If update checking is enabled, this rate limits the auto-check that happens at startup
+    const int STARTUP_CHECK_INTERVAL_HOURS = 4;
 
     double latestVersionNum;
 


### PR DESCRIPTION
* https://github.com/jurplel/qView/pull/650/commits/aa03cf049d0656b1fff3dc100bfa87a3c6ce8f7b uncommented the flag to disable update check support, I'm assuming that was for testing and not intentionally committed.
* When fetching from the API, it requested the full release list. This caused unnecessary network traffic and would notify for pre-release versions. Now it asks just for the latest version.
* Changelog was displayed different on macOS vs Windows. This is because the changelog from the API uses \r\n as newline, whereas the splitting happened on \n, leaving \r still present. On macOS the notification dialog looked fine and had newlines, but this wasn't the case on Windows (see screenshots for before/after).
* Implement rate limiting for the automatic checks at startup, so it doesn't happen more frequently than every 4 hours.

![before](https://github.com/jurplel/qView/assets/6741660/f5ab8eb4-1c4c-4de6-9164-77323f9da4d4)

![after](https://github.com/jurplel/qView/assets/6741660/38caec05-4376-46cd-a29d-0dd6f74c4753)
