### PR TITLE
Non-modal errors via background painting

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -39,6 +39,7 @@ MainWindow::MainWindow(QWidget *parent) :
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
+    setAttribute(Qt::WA_OpaquePaintEvent);
 
     // Initialize variables
     justLaunchedWithImage = false;
@@ -266,6 +267,16 @@ void MainWindow::mouseDoubleClickEvent(QMouseEvent *event)
     QMainWindow::mouseDoubleClickEvent(event);
 }
 
+void MainWindow::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+
+    QPainter painter(this);
+
+    const QColor &backgroundColor = customBackgroundColor.isValid() ? customBackgroundColor : painter.background().color();
+    painter.fillRect(rect(), backgroundColor);
+}
+
 void MainWindow::openFile(const QString &fileName)
 {
     graphicsView->loadFile(fileName);
@@ -277,6 +288,9 @@ void MainWindow::settingsUpdated()
     auto &settingsManager = qvApp->getSettingsManager();
 
     buildWindowTitle();
+
+    //bgcolor
+    customBackgroundColor = settingsManager.getBoolean("bgcolorenabled") ? QColor(settingsManager.getString("bgcolor")) : QColor();
 
     // menubarenabled
     bool menuBarEnabled = settingsManager.getBoolean("menubarenabled");
@@ -300,6 +314,9 @@ void MainWindow::settingsUpdated()
     ui->fullscreenLabel->setVisible(qvApp->getSettingsManager().getBoolean("fullscreendetails") && (windowState() == Qt::WindowFullScreen));
 
     setWindowSize();
+
+    // repaint in case background color changed
+    update();
 }
 
 void MainWindow::shortcutsUpdated()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -273,8 +273,20 @@ void MainWindow::paintEvent(QPaintEvent *event)
 
     QPainter painter(this);
 
+    const int viewportY = qMax(getTitlebarOverlap(), graphicsView->mapTo(this, QPoint()).y());
+    const QRect viewportRect = rect().adjusted(0, viewportY, 0, 0);
+
     const QColor &backgroundColor = customBackgroundColor.isValid() ? customBackgroundColor : painter.background().color();
     painter.fillRect(rect(), backgroundColor);
+
+    if (getCurrentFileDetails().errorData.hasError && viewportRect.isValid())
+    {
+        const QVImageCore::ErrorData &errorData = getCurrentFileDetails().errorData;
+        const QString errorMessage = tr("Error occurred opening\n%3\n%2 (Error %1)").arg(QString::number(errorData.errorNum), errorData.errorString, getCurrentFileDetails().fileInfo.fileName());
+        painter.setFont(font());
+        painter.setPen(QVApplication::getPerceivedBrightness(backgroundColor) > 0.5 ? Qt::black : Qt::white);
+        painter.drawText(viewportRect, errorMessage, QTextOption(Qt::AlignCenter));
+    }
 }
 
 void MainWindow::openFile(const QString &fileName)
@@ -350,6 +362,9 @@ void MainWindow::fileChanged()
     if (info->isVisible())
         refreshProperties();
     buildWindowTitle();
+
+    // repaint to handle error message
+    update();
 }
 
 void MainWindow::disableActions()
@@ -531,11 +546,7 @@ void MainWindow::setWindowSize()
     if (menuBar()->isVisible())
         extraWidgetsSize.rheight() += menuBar()->height();
 
-    int titlebarOverlap = 0;
-#ifdef COCOA_LOADED
-    // To account for fullsizecontentview on mac
-    titlebarOverlap = QVCocoaFunctions::getObscuredHeight(window()->windowHandle());
-#endif
+    const int titlebarOverlap = getTitlebarOverlap();
     if (titlebarOverlap != 0)
         extraWidgetsSize.rheight() += titlebarOverlap;
 
@@ -1154,4 +1165,14 @@ void MainWindow::toggleFullScreen()
         storedWindowState = windowState();
         showFullScreen();
     }
+}
+
+int MainWindow::getTitlebarOverlap() const
+{
+#ifdef COCOA_LOADED
+    // To account for fullsizecontentview on mac
+    return QVCocoaFunctions::getObscuredHeight(window()->windowHandle());
+#endif
+
+    return 0;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -449,9 +449,12 @@ void MainWindow::buildWindowTitle()
             newString = QString::number(getCurrentFileDetails().loadedIndexInFolder+1);
             newString += "/" + QString::number(getCurrentFileDetails().folderFileInfoList.count());
             newString += " - " + getCurrentFileDetails().fileInfo.fileName();
-            newString += " - "  + QString::number(getCurrentFileDetails().baseImageSize.width());
-            newString += "x" + QString::number(getCurrentFileDetails().baseImageSize.height());
-            newString += " - " + QVInfoDialog::formatBytes(getCurrentFileDetails().fileInfo.size());
+            if (!getCurrentFileDetails().errorData.hasError)
+            {
+                newString += " - "  + QString::number(getCurrentFileDetails().baseImageSize.width());
+                newString += "x" + QString::number(getCurrentFileDetails().baseImageSize.height());
+                newString += " - " + QVInfoDialog::formatBytes(getCurrentFileDetails().fileInfo.size());
+            }
             newString += " - qView";
             break;
         }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -141,6 +141,8 @@ protected:
 
     void mouseDoubleClickEvent(QMouseEvent *event) override;
 
+    void paintEvent(QPaintEvent *event) override;
+
 protected slots:
     void settingsUpdated();
     void shortcutsUpdated();
@@ -157,6 +159,8 @@ private:
     QShortcut *escShortcut;
 
     QVInfoDialog *info;
+
+    QColor customBackgroundColor;
 
     bool justLaunchedWithImage;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -111,6 +111,8 @@ public:
 
     void toggleFullScreen();
 
+    int getTitlebarOverlap() const;
+
     const QVImageCore::FileDetails& getCurrentFileDetails() const { return graphicsView->getCurrentFileDetails(); }
 
 public slots:

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -390,3 +390,8 @@ void QVApplication::defineFilterLists()
     nameFilterList << filterString;
     nameFilterList << tr("All Files") + " (*)";
 }
+
+qreal QVApplication::getPerceivedBrightness(const QColor &color)
+{
+    return (color.red() * 0.299 + color.green() * 0.587 + color.blue() * 0.114) / 255.0;
+}

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -77,6 +77,8 @@ public:
 
     ActionManager &getActionManager() { return actionManager; }
 
+    static qreal getPerceivedBrightness(const QColor &color);
+
 private:
 
     QList<MainWindow*> lastActiveWindows;

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -20,6 +20,7 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     setDragMode(QGraphicsView::ScrollHandDrag);
     setFrameShape(QFrame::NoFrame);
     setTransformationAnchor(QGraphicsView::NoAnchor);
+    viewport()->setAutoFillBackground(false);
 
     // part of a pathetic attempt at gesture support
     grabGesture(Qt::PinchGesture);
@@ -683,21 +684,6 @@ void QVGraphicsView::centerOn(const QGraphicsItem *item)
 void QVGraphicsView::settingsUpdated()
 {
     auto &settingsManager = qvApp->getSettingsManager();
-
-    //bgcolor
-    QBrush newBrush;
-    newBrush.setStyle(Qt::SolidPattern);
-    if (!settingsManager.getBoolean("bgcolorenabled"))
-    {
-        newBrush.setColor(QColor(0, 0, 0, 0));
-    }
-    else
-    {
-        QColor newColor;
-        newColor.setNamedColor(settingsManager.getString("bgcolor"));
-        newBrush.setColor(newColor);
-    }
-    setBackgroundBrush(newBrush);
 
     //filtering
     if (settingsManager.getBoolean("filteringenabled"))

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -53,7 +53,6 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     connect(&imageCore, &QVImageCore::animatedFrameChanged, this, &QVGraphicsView::animatedFrameChanged);
     connect(&imageCore, &QVImageCore::fileChanged, this, &QVGraphicsView::postLoad);
     connect(&imageCore, &QVImageCore::updateLoadedPixmapItem, this, &QVGraphicsView::updateLoadedPixmapItem);
-    connect(&imageCore, &QVImageCore::readError, this, &QVGraphicsView::error);
 
     // Should replace the other timer eventually
     expensiveScaleTimerNew = new QTimer(this);
@@ -679,16 +678,6 @@ void QVGraphicsView::centerOn(qreal x, qreal y)
 void QVGraphicsView::centerOn(const QGraphicsItem *item)
 {
     centerOn(item->sceneBoundingRect().center());
-}
-
-void QVGraphicsView::error(int errorNum, const QString &errorString, const QString &fileName)
-{
-    if (!errorString.isEmpty())
-    {
-        closeImage();
-        QMessageBox::critical(this, tr("Error"), tr("Error occurred opening \"%3\":\n%2 (Error %1)").arg(QString::number(errorNum), errorString, fileName));
-        return;
-    }
 }
 
 void QVGraphicsView::settingsUpdated()

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -113,8 +113,6 @@ private slots:
 
     void updateLoadedPixmapItem();
 
-    void error(int errorNum, const QString &errorString, const QString &fileName);
-
 private:
 
 

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -34,6 +34,13 @@ public:
         QString mimeType;
     };
 
+    struct ErrorData
+    {
+        bool hasError;
+        int errorNum;
+        QString errorString;
+    };
+
     struct FileDetails
     {
         QFileInfo fileInfo;
@@ -45,6 +52,7 @@ public:
         QSize baseImageSize;
         QSize loadedPixmapSize;
         QElapsedTimer timeSinceLoaded;
+        ErrorData errorData;
 
         void updateLoadedIndexInFolder();
     };
@@ -56,12 +64,13 @@ public:
         qint64 fileSize;
         QSize imageSize;
         QColorSpace targetColorSpace;
+        ErrorData errorData;
     };
 
     explicit QVImageCore(QObject *parent = nullptr);
 
     void loadFile(const QString &fileName, bool isReloading = false);
-    ReadData readFile(const QString &fileName, const QColorSpace &targetColorSpace, bool forCache);
+    ReadData readFile(const QString &fileName, const QColorSpace &targetColorSpace);
     void loadPixmap(const ReadData &readData);
     void closeImage();
     QList<CompatibleFile> getCompatibleFiles(const QString &dirPath) const;
@@ -99,7 +108,9 @@ signals:
 
     void fileChanged();
 
-    void readError(int errorNum, const QString &errorString, const QString &fileName);
+protected:
+    void loadEmptyPixmap();
+    FileDetails getEmptyFileDetails();
 
 private:
     QPixmap loadedPixmap;


### PR DESCRIPTION
Similar to #649 but overrides `MainWindow::paintEvent` to display the error message. Fixes #387.

<img width="413" alt="image" src="https://github.com/jurplel/qView/assets/6741660/6e5fa633-155d-46c8-bad1-021395e3eb80">
