### PR TITLE
Windows: Workaround for crashing with older Visual C++ runtimes

### DIFF
--- a/dist/scripts/build.ps1
+++ b/dist/scripts/build.ps1
@@ -9,12 +9,13 @@ if ($IsWindows) {
     dist/scripts/vcvars.ps1
 }
 
-if ($env:buildArch -eq 'Universal') {
-    qmake QMAKE_APPLE_DEVICE_ARCHS="x86_64 arm64" $args[0] PREFIX=$Prefix DEFINES+="$env:nightlyDefines"
-} else {
-    qmake $args[0] PREFIX=$Prefix DEFINES+="$env:nightlyDefines"
+if ($IsMacOS -and $env:buildArch -eq 'Universal') {
+    $argDeviceArchs = 'QMAKE_APPLE_DEVICE_ARCHS=x86_64 arm64'
+} elseif ($IsWindows) {
+    # Workaround for https://developercommunity.visualstudio.com/t/10664660
+    $argVcrMutexWorkaround = 'DEFINES+=_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR'
 }
-
+qmake $args[0] PREFIX=$Prefix DEFINES+="$env:nightlyDefines" $argVcrMutexWorkaround $argDeviceArchs
 
 if ($IsWindows) {
     nmake


### PR DESCRIPTION
**PREREQ:** https://github.com/jurplel/kimageformats-binaries/pull/5 (wait until merged / uploaded to release)

Don't know if this is needed, i.e. whether any code on the qView side (plus included headers / moc_ files / whatever) could be using std::mutex, but better safe than sorry. If you're confident it's not needed, feel free to close.