### PR TITLE
Future Qt compatibility

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addPositionalArgument(QObject::tr("file"), QObject::tr("The file to open."));
-#if defined Q_OS_WIN && WIN32_LOADED
+#if defined Q_OS_WIN && WIN32_LOADED && QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
     // Workaround for unicode characters getting mangled in certain cases. To support unicode arguments on
     // Windows, QCoreApplication normally ignores argv and gets them from the Windows API instead. But this
     // only happens if it thinks argv hasn't been modified prior to being passed into QCoreApplication's

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -41,6 +41,12 @@ MainWindow::MainWindow(QWidget *parent) :
     setAttribute(Qt::WA_DeleteOnClose);
     setAttribute(Qt::WA_OpaquePaintEvent);
 
+#if defined COCOA_LOADED && QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    // Allow the titlebar to overlap widgets with full size content view
+    setAttribute(Qt::WA_ContentsMarginsRespectsSafeArea, false);
+    centralWidget()->setAttribute(Qt::WA_ContentsMarginsRespectsSafeArea, false);
+#endif
+
     // Initialize variables
     justLaunchedWithImage = false;
     storedWindowState = Qt::WindowNoState;

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -32,6 +32,15 @@ QVApplication::QVApplication(int &argc, char **argv) : QApplication(argc, argv)
         checkUpdates(true);
     }
 
+    // Block any erroneous icons from showing up on mac and windows
+    // (this is overridden in some cases)
+#if defined Q_OS_MACOS || defined Q_OS_WIN
+    setAttribute(Qt::AA_DontShowIconsInMenus);
+#endif
+    // Adwaita Qt styles should hide icons for a more consistent look
+    if (style()->objectName() == "adwaita-dark" || style()->objectName() == "adwaita")
+        setAttribute(Qt::AA_DontShowIconsInMenus);
+
     // Setup macOS dock menu
     dockMenu = new QMenu();
     connect(dockMenu, &QMenu::triggered, this, [](QAction *triggeredAction) {
@@ -59,15 +68,6 @@ QVApplication::QVApplication(int &argc, char **argv) : QApplication(argc, argv)
 #ifdef Q_OS_MACOS
     setQuitOnLastWindowClosed(getSettingsManager().getBoolean("quitonlastwindow"));
 #endif
-
-    // Block any erroneous icons from showing up on mac and windows
-    // (this is overridden in some cases)
-#if defined Q_OS_MACOS || defined Q_OS_WIN
-    setAttribute(Qt::AA_DontShowIconsInMenus);
-#endif
-    // Adwaita Qt styles should hide icons for a more consistent look
-    if (style()->objectName() == "adwaita-dark" || style()->objectName() == "adwaita")
-        setAttribute(Qt::AA_DontShowIconsInMenus);
 
     hideIncompatibleActions();
 }


### PR DESCRIPTION
1) Limit workaround for [QTBUG-125380](https://bugreports.qt.io/browse/QTBUG-125380) which was fixed in 6.7.2.
2) https://github.com/qt/qtbase/commit/9bbfdd6844f986de861336c0a5e3c43dbc8d1898 made `QIcon::fromTheme` start returning icons on macOS. There was already code to mostly turn off the icons, but it only affected the window menus. If you close all windows and were left with just the application's global menu bar or whatever it's called, icons were showing there. This also causes a serious delay any time a window is opened or closed, since something about menu icons in macOS on Qt is really slow and they don't get cached properly (remember we worked around that in the past for the Open With / Recent submenus). It looks like a later change, https://github.com/qt/qtbase/commit/d671e1af3b736ee7d866323246fc2190fc5e076a, will hide menu icons by default on macOS, but my commit will ensure things work as intended with Qt 6.7.0 - Qt 6.7.2 if someone compiles qView for those versions.
<img width="206" alt="Screenshot 2024-07-05 at 6 28 49 PM" src="https://github.com/jurplel/qView/assets/6741660/70c09f36-a646-4a2b-b253-888021694346">

3) https://github.com/qt/qtbase/commit/fd97a820df797a961dfd1135fe20fe15325572d1 implements a "safe area margin" concept on macOS which breaks qView's full size content view feature. With Qt 6.8 beta, this results in the graphics view widget not being placed under the titlebar as intended, meaning the cool translucent effect with the image underneath the titlebar doesn't work, and when fitting the image, the calculation is broken leaving a gap at the top. My commit opts out of this "safe area margin" feature.
<img width="254" alt="Screenshot 2024-07-05 at 6 31 15 PM" src="https://github.com/jurplel/qView/assets/6741660/f144dcd4-b52c-4b27-9797-1475b34c846a">