### PR TITLE
Preloader optimization

### DIFF
--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -137,6 +137,8 @@ private:
     unsigned randomSortSeed;
 
     QStringList lastFilesPreloaded;
+    QStringList preloadFilesInProgress;
+    QString waitingOnPreloadFile;
 
     int largestDimension;
 


### PR DESCRIPTION
When rapidly navigating through images, I noticed there can be some wasted effort because it's possible for the preloader to start working on a file, but if it's not quite done by the time a load of the same file is requested, it's loaded from scratch instead of waiting for the preloader to finish. This PR makes the preloader keep track of which files it's working on in order to avoid that.