### PR TITLE
GraphicsView overhaul

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,12 @@
 
 int main(int argc, char *argv[])
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif
     QCoreApplication::setOrganizationName("qView");
     QCoreApplication::setApplicationName("qView");
     QCoreApplication::setApplicationVersion(QString::number(VERSION));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -54,7 +54,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // Connect graphicsview signals
     connect(graphicsView, &QVGraphicsView::fileChanged, this, &MainWindow::fileChanged);
-    connect(graphicsView, &QVGraphicsView::updatedLoadedPixmapItem, this, &MainWindow::setWindowSize);
     connect(graphicsView, &QVGraphicsView::cancelSlideshow, this, &MainWindow::cancelSlideshow);
 
     // Initialize escape shortcut
@@ -381,6 +380,7 @@ void MainWindow::fileChanged()
     if (info->isVisible())
         refreshProperties();
     buildWindowTitle();
+    setWindowSize();
 
     // repaint to handle error message
     update();
@@ -547,8 +547,9 @@ void MainWindow::setWindowSize()
     qreal maxWindowResizedPercentage = qvApp->getSettingsManager().getInteger("maxwindowresizedpercentage")/100.0;
 
 
+    const int fitOverscan = graphicsView->getFitOverscan();
     QSize imageSize = getCurrentFileDetails().loadedPixmapSize;
-    imageSize -= QSize(4, 4);
+    imageSize -= QSize(fitOverscan * 2, fitOverscan * 2);
 
 
     // Try to grab the current screen
@@ -996,7 +997,7 @@ void MainWindow::zoomOut()
 
 void MainWindow::resetZoom()
 {
-    graphicsView->resetScale();
+    graphicsView->zoomToFit();
 }
 
 void MainWindow::originalSize()
@@ -1018,13 +1019,13 @@ void MainWindow::rotateLeft()
 
 void MainWindow::mirror()
 {
-    graphicsView->scale(-1, 1);
+    graphicsView->mirrorImage();
     resetZoom();
 }
 
 void MainWindow::flip()
 {
-    graphicsView->scale(1, -1);
+    graphicsView->flipImage();
     resetZoom();
 }
 
@@ -1072,7 +1073,7 @@ void MainWindow::saveFrameAs()
             nextFrame();
 
         graphicsView->getLoadedMovie().currentPixmap().save(fileName, nullptr, 100);
-        graphicsView->resetScale();
+        graphicsView->zoomToFit();
     });
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -54,6 +54,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // Connect graphicsview signals
     connect(graphicsView, &QVGraphicsView::fileChanged, this, &MainWindow::fileChanged);
+    connect(graphicsView, &QVGraphicsView::zoomLevelChanged, this, &MainWindow::zoomLevelChanged);
     connect(graphicsView, &QVGraphicsView::cancelSlideshow, this, &MainWindow::cancelSlideshow);
 
     // Initialize escape shortcut
@@ -386,6 +387,11 @@ void MainWindow::fileChanged()
     update();
 }
 
+void MainWindow::zoomLevelChanged()
+{
+    buildWindowTitle();
+}
+
 void MainWindow::disableActions()
 {
     const auto &actionLibrary = qvApp->getActionManager().getActionLibrary();
@@ -490,14 +496,16 @@ void MainWindow::buildWindowTitle()
         }
         case 2:
         {
-            newString = QString::number(getCurrentFileDetails().loadedIndexInFolder+1);
+            newString = QString::number(graphicsView->getZoomLevel() * 100.0, 'f', 1) + "%";
+            newString += " - " + QString::number(getCurrentFileDetails().loadedIndexInFolder+1);
             newString += "/" + QString::number(getCurrentFileDetails().folderFileInfoList.count());
             newString += " - " + getCurrentFileDetails().fileInfo.fileName();
             break;
         }
         case 3:
         {
-            newString = QString::number(getCurrentFileDetails().loadedIndexInFolder+1);
+            newString = QString::number(graphicsView->getZoomLevel() * 100.0, 'f', 1) + "%";
+            newString += " - " + QString::number(getCurrentFileDetails().loadedIndexInFolder+1);
             newString += "/" + QString::number(getCurrentFileDetails().folderFileInfoList.count());
             newString += " - " + getCurrentFileDetails().fileInfo.fileName();
             if (!getCurrentFileDetails().errorData.hasError)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -126,6 +126,8 @@ public slots:
 
     void fileChanged();
 
+    void zoomLevelChanged();
+
     void disableActions();
 
 protected:

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -56,6 +56,11 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     expensiveScaleTimer->setInterval(50);
     connect(expensiveScaleTimer, &QTimer::timeout, this, [this]{applyExpensiveScaling();});
 
+    emitZoomLevelChangedTimer = new QTimer(this);
+    emitZoomLevelChangedTimer->setSingleShot(true);
+    emitZoomLevelChangedTimer->setInterval(50);
+    connect(emitZoomLevelChangedTimer, &QTimer::timeout, this, [this]{emit zoomLevelChanged();});
+
     loadedPixmapItem = new QGraphicsPixmapItem();
     scene->addItem(loadedPixmapItem);
 
@@ -315,6 +320,8 @@ void QVGraphicsView::zoomAbsolute(const qreal absoluteLevel, const QPoint &pos)
 
     if (isScalingEnabled)
         expensiveScaleTimer->start();
+
+    emitZoomLevelChangedTimer->start();
 }
 
 void QVGraphicsView::applyExpensiveScaling()

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -42,7 +42,7 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     zoomMultiplier = 1.25;
 
     // Initialize other variables
-    fitOverscan = 2;
+    fitOverscan = 0;
     zoomLevel = 1.0;
     appliedDpiAdjustment = 1.0;
     appliedExpensiveScaleZoomLevel = 0.0;
@@ -408,15 +408,41 @@ void QVGraphicsView::zoomToFit()
 
     qreal targetRatio;
 
+    // Each mode will check if the rounded image size already produces the desired fit,
+    // in which case we can use exactly 1.0 to avoid unnecessary scaling
+
     switch (cropMode) { // should be enum tbh
     case 1: // only take into account height
-        targetRatio = fitYRatio;
+        if (qRound(effectiveImageSize.height()) == viewSize.height())
+            targetRatio = 1.0;
+        else
+            targetRatio = fitYRatio;
         break;
     case 2: // only take into account width
-        targetRatio = fitXRatio;
+        if (qRound(effectiveImageSize.width()) == viewSize.width())
+            targetRatio = 1.0;
+        else
+            targetRatio = fitXRatio;
         break;
     default:
-        targetRatio = qMin(fitXRatio, fitYRatio);
+        if ((qRound(effectiveImageSize.height()) == viewSize.height() && qRound(effectiveImageSize.width()) <= viewSize.width()) ||
+            (qRound(effectiveImageSize.width()) == viewSize.width() && qRound(effectiveImageSize.height()) <= viewSize.height()))
+        {
+            targetRatio = 1.0;
+        }
+        else
+        {
+            QSize xRatioSize = (effectiveImageSize * fitXRatio * devicePixelRatioF()).toSize();
+            QSize yRatioSize = (effectiveImageSize * fitYRatio * devicePixelRatioF()).toSize();
+            QSize maxSize = (QSizeF(viewSize) * devicePixelRatioF()).toSize();
+            // If the fit ratios are extremely close, it's possible that both are sufficient to
+            // contain the image, but one results in the opposing dimension getting rounded down
+            // to just under the view size, so use the larger of the two ratios in that case.
+            if (xRatioSize.boundedTo(maxSize) == xRatioSize && yRatioSize.boundedTo(maxSize) == yRatioSize)
+                targetRatio = qMax(fitXRatio, fitYRatio);
+            else
+                targetRatio = qMin(fitXRatio, fitYRatio);
+        }
         break;
     }
 
@@ -575,13 +601,26 @@ qreal QVGraphicsView::getContentToViewportRatio() const
 
 void QVGraphicsView::setTransformScale(qreal value)
 {
+#ifdef Q_OS_WIN
+    // On Windows, the positioning of scaled pixels seems to follow a floor rule rather
+    // than rounding, so increase the scale just a hair to cover rounding errors in case
+    // the desired scale was targeting an integer pixel boundary.
+    value *= 1.0 + std::numeric_limits<double>::epsilon();
+#endif
     setTransform(getTransformWithNoScaling().scale(value, value));
 }
 
 QTransform QVGraphicsView::getTransformWithNoScaling() const
 {
-    const QRectF unityRect = transform().mapRect(QRectF(0, 0, 1, 1));
-    return transform().scale(1.0 / unityRect.width(), 1.0 / unityRect.height());
+    const QTransform t = transform();
+    // Only intended to handle combinations of scaling, mirroring, flipping, and rotation
+    // in increments of 90 degrees. A seemingly simpler approach would be to scale the
+    // transform by the inverse of its scale factor, but the resulting scale factor may
+    // not exactly equal 1 due to floating point rounding errors.
+    if (t.type() == QTransform::TxRotate)
+        return { 0, t.m12() < 0 ? -1.0 : 1.0, t.m21() < 0 ? -1.0 : 1.0, 0, 0, 0 };
+    else
+        return { t.m11() < 0 ? -1.0 : 1.0, 0, 0, t.m22() < 0 ? -1.0 : 1.0, 0, 0 };
 }
 
 qreal QVGraphicsView::getDpiAdjustment() const

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -38,29 +38,23 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
     isLoopFoldersEnabled = true;
     isCursorZoomEnabled = true;
     cropMode = 0;
-    scaleFactor = 1.25;
+    zoomMultiplier = 1.25;
 
     // Initialize other variables
-    currentScale = 1.0;
-    scaledSize = QSize();
-    maxScalingTwoSize = 3;
-    isOriginalSize = false;
+    fitOverscan = 2;
+    zoomLevel = 1.0;
+    appliedExpensiveScaleZoomLevel = 0.0;
     lastZoomEventPos = QPoint(-1, -1);
     lastZoomRoundingError = QPointF();
     lastScrollRoundingError = QPointF();
 
-    zoomBasisScaleFactor = 1.0;
-
     connect(&imageCore, &QVImageCore::animatedFrameChanged, this, &QVGraphicsView::animatedFrameChanged);
     connect(&imageCore, &QVImageCore::fileChanged, this, &QVGraphicsView::postLoad);
-    connect(&imageCore, &QVImageCore::updateLoadedPixmapItem, this, &QVGraphicsView::updateLoadedPixmapItem);
 
-    // Should replace the other timer eventually
-    expensiveScaleTimerNew = new QTimer(this);
-    expensiveScaleTimerNew->setSingleShot(true);
-    expensiveScaleTimerNew->setInterval(50);
-    connect(expensiveScaleTimerNew, &QTimer::timeout, this, [this]{scaleExpensively();});
-
+    expensiveScaleTimer = new QTimer(this);
+    expensiveScaleTimer->setSingleShot(true);
+    expensiveScaleTimer->setInterval(50);
+    connect(expensiveScaleTimer, &QTimer::timeout, this, [this]{applyExpensiveScaling();});
 
     loadedPixmapItem = new QGraphicsPixmapItem();
     scene->addItem(loadedPixmapItem);
@@ -76,10 +70,7 @@ QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
 void QVGraphicsView::resizeEvent(QResizeEvent *event)
 {
     QGraphicsView::resizeEvent(event);
-    if (!isOriginalSize)
-        resetScale();
-    else
-        centerOn(loadedPixmapItem);
+    zoomToFit();
 }
 
 void QVGraphicsView::dropEvent(QDropEvent *event)
@@ -138,14 +129,14 @@ bool QVGraphicsView::event(QEvent *event)
 
             if (changeFlags & QPinchGesture::ScaleFactorChanged) {
                 const QPoint hotPoint = mapFromGlobal(pinchGesture->hotSpot().toPoint());
-                zoom(pinchGesture->scaleFactor(), hotPoint);
+                zoomRelative(pinchGesture->scaleFactor(), hotPoint);
             }
 
             // Fun rotation stuff maybe later
 //            if (changeFlags & QPinchGesture::RotationAngleChanged) {
 //                qreal rotationDelta = pinchGesture->rotationAngle() - pinchGesture->lastRotationAngle();
 //                rotate(rotationDelta);
-//                centerOn(loadedPixmapItem);
+//                centerImage();
 //            }
             return true;
         }
@@ -189,17 +180,17 @@ void QVGraphicsView::wheelEvent(QWheelEvent *event)
     const int yDelta = event->angleDelta().y();
     const qreal yScale = 120.0;
 
-    if (yDelta == 0)
+    if (yDelta == 0 || !getCurrentFileDetails().isPixmapLoaded)
         return;
 
     const qreal fractionalWheelClicks = qFabs(yDelta) / yScale;
-    const qreal zoomAmountPerWheelClick = scaleFactor - 1.0;
+    const qreal zoomAmountPerWheelClick = zoomMultiplier - 1.0;
     qreal zoomFactor = 1.0 + (fractionalWheelClicks * zoomAmountPerWheelClick);
 
     if (yDelta < 0)
         zoomFactor = qPow(zoomFactor, -1);
 
-    zoom(zoomFactor, eventPos);
+    zoomRelative(zoomFactor, eventPos);
 }
 
 // Functions
@@ -254,7 +245,14 @@ void QVGraphicsView::reloadFile()
 
 void QVGraphicsView::postLoad()
 {
-    updateLoadedPixmapItem();
+    // Set the pixmap to the new image and reset the transform's scale to a known value
+    removeExpensiveScaling();
+
+    zoomToFit();
+
+    if (isScalingEnabled)
+        expensiveScaleTimer->start();
+
     qvApp->getActionManager().addFileToRecentsList(getCurrentFileDetails().fileInfo);
 
     emit fileChanged();
@@ -262,24 +260,26 @@ void QVGraphicsView::postLoad()
 
 void QVGraphicsView::zoomIn(const QPoint &pos)
 {
-    zoom(scaleFactor, pos);
+    zoomRelative(zoomMultiplier, pos);
 }
 
 void QVGraphicsView::zoomOut(const QPoint &pos)
 {
-    zoom(qPow(scaleFactor, -1), pos);
+    zoomRelative(qPow(zoomMultiplier, -1), pos);
 }
 
-void QVGraphicsView::zoom(qreal scaleFactor, const QPoint &pos)
+void QVGraphicsView::zoomRelative(qreal relativeLevel, const QPoint &pos)
 {
-    //don't zoom too far out, dude
-    currentScale *= scaleFactor;
-    if (currentScale >= 500 || currentScale <= 0.01)
-    {
-        currentScale *= qPow(scaleFactor, -1);
-        return;
-    }
+    const qreal absoluteLevel = zoomLevel * relativeLevel;
 
+    if (absoluteLevel >= 500 || absoluteLevel <= 0.01)
+        return;
+
+    zoomAbsolute(absoluteLevel, pos);
+}
+
+void QVGraphicsView::zoomAbsolute(const qreal absoluteLevel, const QPoint &pos)
+{
     if (pos != lastZoomEventPos)
     {
         lastZoomEventPos = pos;
@@ -287,12 +287,20 @@ void QVGraphicsView::zoom(qreal scaleFactor, const QPoint &pos)
     }
     const QPointF scenePos = mapToScene(pos) - lastZoomRoundingError;
 
-    zoomBasisScaleFactor *= scaleFactor;
-    setTransform(QTransform(zoomBasis).scale(zoomBasisScaleFactor, zoomBasisScaleFactor));
-    absoluteTransform.scale(scaleFactor, scaleFactor);
+    if (appliedExpensiveScaleZoomLevel != 0.0)
+    {
+        const qreal baseTransformScale = 1.0 / devicePixelRatioF();
+        const qreal relativeLevel = absoluteLevel / appliedExpensiveScaleZoomLevel;
+        setTransformScale(baseTransformScale * relativeLevel);
+    }
+    else
+    {
+        setTransformScale(absoluteLevel);
+    }
+    zoomLevel = absoluteLevel;
 
     // If we are zooming in, we have a point to zoom towards, the mouse is on top of the viewport, and cursor zooming is enabled
-    if (currentScale > 1.00001 && pos != QPoint(-1, -1) && underMouse() && isCursorZoomEnabled)
+    if (getContentToViewportRatio() >= 1.0 && pos != QPoint(-1, -1) && underMouse() && isCursorZoomEnabled)
     {
         const QPointF p1mouse = mapFromScene(scenePos);
         const QPointF move = p1mouse - pos;
@@ -302,93 +310,49 @@ void QVGraphicsView::zoom(qreal scaleFactor, const QPoint &pos)
     }
     else
     {
-        centerOn(loadedPixmapItem);
+        centerImage();
     }
 
-    if (isScalingEnabled && !isOriginalSize)
-    {
-        expensiveScaleTimerNew->start();
-    }
+    if (isScalingEnabled)
+        expensiveScaleTimer->start();
 }
 
-void QVGraphicsView::scaleExpensively()
+void QVGraphicsView::applyExpensiveScaling()
 {
-    // Determine if mirrored or flipped
-    bool mirrored = false;
-    if (transform().m11() < 0)
-        mirrored = true;
-
-    bool flipped = false;
-    if (transform().m22() < 0)
-        flipped = true;
+    if (!isScalingEnabled || !getCurrentFileDetails().isPixmapLoaded)
+        return;
 
     // If we are above maximum scaling size
-    if ((currentScale >= maxScalingTwoSize) ||
-        (!isScalingTwoEnabled && currentScale > 1.00001))
+    if (getContentToViewportRatio() > (isScalingTwoEnabled ? 3.0 : 1.00001))
     {
         // Return to original size
-        makeUnscaled();
+        removeExpensiveScaling();
         return;
     }
 
-    // Map size of the original pixmap to the scale acquired in fitting with modification from zooming percentage
-    const QRectF mappedRect = absoluteTransform.mapRect(QRectF({}, getCurrentFileDetails().loadedPixmapSize));
-    const QSizeF mappedPixmapSize = mappedRect.size() * devicePixelRatioF();
-
-    // Undo mirror/flip before new transform
-    if (mirrored)
-        scale(-1, 1);
-
-    if (flipped)
-        scale(1, -1);
+    // Calculate scaled resolution
+    const QSizeF mappedSize = QSizeF(getCurrentFileDetails().loadedPixmapSize) * zoomLevel * devicePixelRatioF();
 
     // Set image to scaled version
-    loadedPixmapItem->setPixmap(imageCore.scaleExpensively(mappedPixmapSize));
+    loadedPixmapItem->setPixmap(imageCore.scaleExpensively(mappedSize));
 
-    // Reset transformation
-    setTransform(QTransform::fromScale(qPow(devicePixelRatioF(), -1), qPow(devicePixelRatioF(), -1)));
-
-    // Redo mirror/flip after new transform
-    if (mirrored)
-        scale(-1, 1);
-
-    if (flipped)
-        scale(1, -1);
-
-    // Set zoombasis
-    zoomBasis = transform();
-    zoomBasisScaleFactor = 1.0;
+    // Set appropriate scale factor
+    const qreal newTransformScale = 1.0 / devicePixelRatioF();
+    setTransformScale(newTransformScale);
+    appliedExpensiveScaleZoomLevel = zoomLevel;
 }
 
-void QVGraphicsView::makeUnscaled()
+void QVGraphicsView::removeExpensiveScaling()
 {
-    // Determine if mirrored or flipped
-    bool mirrored = false;
-    if (transform().m11() < 0)
-        mirrored = true;
-
-    bool flipped = false;
-    if (transform().m22() < 0)
-        flipped = true;
-
     // Return to original size
     if (getCurrentFileDetails().isMovieLoaded)
         loadedPixmapItem->setPixmap(getLoadedMovie().currentPixmap());
     else
         loadedPixmapItem->setPixmap(getLoadedPixmap());
 
-    setTransform(absoluteTransform);
-
-    // Redo mirror/flip after new transform
-    if (mirrored)
-        scale(-1, 1);
-
-    if (flipped)
-        scale(1, -1);
-
-    // Reset transformation
-    zoomBasis = transform();
-    zoomBasisScaleFactor = 1.0;
+    // Set appropriate scale factor
+    setTransformScale(zoomLevel);
+    appliedExpensiveScaleZoomLevel = 0.0;
 }
 
 void QVGraphicsView::animatedFrameChanged(QRect rect)
@@ -397,7 +361,7 @@ void QVGraphicsView::animatedFrameChanged(QRect rect)
 
     if (isScalingEnabled)
     {
-        scaleExpensively();
+        applyExpensiveScaling();
     }
     else
     {
@@ -405,51 +369,59 @@ void QVGraphicsView::animatedFrameChanged(QRect rect)
     }
 }
 
-void QVGraphicsView::updateLoadedPixmapItem()
-{
-    //set pixmap and offset
-    loadedPixmapItem->setPixmap(getLoadedPixmap());
-    scaledSize = loadedPixmapItem->boundingRect().size().toSize();
-
-    resetScale();
-
-    emit updatedLoadedPixmapItem();
-}
-
-void QVGraphicsView::resetScale()
+void QVGraphicsView::zoomToFit()
 {
     if (!getCurrentFileDetails().isPixmapLoaded)
         return;
 
-    fitInViewMarginless(loadedPixmapItem);
+    QSizeF effectiveImageSize = getEffectiveOriginalSize();
+    QSize viewSize = getUsableViewportRect(true).size();
 
-    if (isScalingEnabled)
-        expensiveScaleTimerNew->start();
+    if (viewSize.isEmpty())
+        return;
+
+    qreal fitXRatio = viewSize.width() / effectiveImageSize.width();
+    qreal fitYRatio = viewSize.height() / effectiveImageSize.height();
+
+    qreal targetRatio;
+
+    switch (cropMode) { // should be enum tbh
+    case 1: // only take into account height
+        targetRatio = fitYRatio;
+        break;
+    case 2: // only take into account width
+        targetRatio = fitXRatio;
+        break;
+    default:
+        targetRatio = qMin(fitXRatio, fitYRatio);
+        break;
+    }
+
+    if (targetRatio > 1.0 && !isPastActualSizeEnabled)
+        targetRatio = 1.0;
+
+    zoomAbsolute(targetRatio);
 }
 
 void QVGraphicsView::originalSize()
 {
-    if (isOriginalSize)
-    {
-        // If we are at the actual original size
-        if (transform() == QTransform())
-        {
-            resetScale(); // back to normal mode
-            return;
-        }
-    }
-    makeUnscaled();
-
-    resetTransform();
-    centerOn(loadedPixmapItem);
-
-    zoomBasis = transform();
-    zoomBasisScaleFactor = 1.0;
-    absoluteTransform = transform();
-
-    isOriginalSize = true;
+    zoomAbsolute(1.0);
 }
 
+void QVGraphicsView::centerImage()
+{
+    const QRect viewRect = getUsableViewportRect();
+    const QRect contentRect = getContentRect().toRect();
+    const int hOffset = isRightToLeft() ?
+        horizontalScrollBar()->minimum() + horizontalScrollBar()->maximum() - contentRect.left() :
+        contentRect.left();
+    const int vOffset = contentRect.top() - viewRect.top();
+    const int hOverflow = contentRect.width() - viewRect.width();
+    const int vOverflow = contentRect.height() - viewRect.height();
+
+    horizontalScrollBar()->setValue(hOffset + (hOverflow / (isRightToLeft() ? -2 : 2)));
+    verticalScrollBar()->setValue(vOffset + (vOverflow / 2));
+}
 
 void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
 {
@@ -547,138 +519,46 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
     loadFile(nextImageFilePath);
 }
 
-void QVGraphicsView::fitInViewMarginless(const QRectF &rect)
+QSizeF QVGraphicsView::getEffectiveOriginalSize() const
+{
+    return getTransformWithNoScaling().mapRect(QRectF(QPoint(), getCurrentFileDetails().loadedPixmapSize)).size();
+}
+
+QRectF QVGraphicsView::getContentRect() const
+{
+    return transform().mapRect(loadedPixmapItem->boundingRect());
+}
+
+QRect QVGraphicsView::getUsableViewportRect(const bool addOverscan) const
 {
 #ifdef COCOA_LOADED
     int obscuredHeight = QVCocoaFunctions::getObscuredHeight(window()->windowHandle());
 #else
     int obscuredHeight = 0;
 #endif
-
-    // Set adjusted image size / bounding rect based on
-    QSize adjustedImageSize = getCurrentFileDetails().loadedPixmapSize;
-    QRectF adjustedBoundingRect = rect;
-
-    switch (cropMode) { // should be enum tbh
-    case 1: // only take into account height
-    {
-        adjustedImageSize.setWidth(1);
-        adjustedBoundingRect.setWidth(1);
-        break;
-    }
-    case 2: // only take into account width
-    {
-        adjustedImageSize.setHeight(1);
-        adjustedBoundingRect.setHeight(1);
-        break;
-    }
-    }
-    adjustedBoundingRect.moveCenter(rect.center());
-
-    if (!scene() || adjustedBoundingRect.isNull())
-        return;
-
-    // Reset the view scale to 1:1.
-    QRectF unity = transform().mapRect(QRectF(0, 0, 1, 1));
-    if (unity.isEmpty())
-        return;
-    scale(1 / unity.width(), 1 / unity.height());
-
-    // Determine what we are resizing to
-    const int adjWidth = width() - MARGIN;
-    const int adjHeight = height() - MARGIN - obscuredHeight;
-
-    QRectF viewRect;
-    // Resize to window size unless you are meant to stop at the actual size, basically
-    if (isPastActualSizeEnabled || (adjustedImageSize.width() >= adjWidth || adjustedImageSize.height() >= adjHeight))
-    {
-        viewRect = viewport()->rect().adjusted(MARGIN, MARGIN, -MARGIN, -MARGIN);
-        viewRect.setHeight(viewRect.height() - obscuredHeight);
-    }
-    else
-    {
-        // stop at actual size
-        viewRect = QRect(QPoint(), getCurrentFileDetails().loadedPixmapSize);
-        QPoint center = this->rect().center();
-        center.setY(center.y() - obscuredHeight);
-        viewRect.moveCenter(center);
-    }
-
-
-    if (viewRect.isEmpty())
-        return;
-
-    // Find the ideal x / y scaling ratio to fit \a rect in the view.
-    QRectF sceneRect = transform().mapRect(adjustedBoundingRect);
-    if (sceneRect.isEmpty())
-        return;
-
-    qreal xratio = viewRect.width() / sceneRect.width();
-    qreal yratio = viewRect.height() / sceneRect.height();
-
-    xratio = yratio = qMin(xratio, yratio);
-
-    // Find and set the transform required to fit the original image
-    // Compact version of above code
-    QRectF sceneRect2 = transform().mapRect(QRectF({}, adjustedImageSize));
-    qreal absoluteRatio = qMin(viewRect.width() / sceneRect2.width(),
-                               viewRect.height() / sceneRect2.height());
-
-    absoluteTransform = QTransform::fromScale(absoluteRatio, absoluteRatio);
-
-    // Scale and center on the center of \a rect.
-    scale(xratio, yratio);
-    centerOn(adjustedBoundingRect.center());
-
-    // variables
-    zoomBasis = transform();
-
-    isOriginalSize = false;
-    currentScale = 1.0;
-    zoomBasisScaleFactor = 1.0;
+    QRect rect = viewport()->rect();
+    rect.setTop(obscuredHeight);
+    if (addOverscan)
+        rect.adjust(-fitOverscan, -fitOverscan, fitOverscan, fitOverscan);
+    return rect;
 }
 
-void QVGraphicsView::fitInViewMarginless(const QGraphicsItem *item)
+qreal QVGraphicsView::getContentToViewportRatio() const
 {
-    return fitInViewMarginless(item->sceneBoundingRect());
+    const QSizeF contentSize = getContentRect().size();
+    const QSizeF viewportSize = getUsableViewportRect(true).size();
+    return qMax(contentSize.width() / viewportSize.width(), contentSize.height() / viewportSize.height());
 }
 
-void QVGraphicsView::centerOn(const QPointF &pos)
+void QVGraphicsView::setTransformScale(qreal value)
 {
-#ifdef COCOA_LOADED
-    int obscuredHeight = QVCocoaFunctions::getObscuredHeight(window()->windowHandle());
-#else
-    int obscuredHeight = 0;
-#endif
-
-    qreal width = viewport()->width();
-    qreal height = viewport()->height() - obscuredHeight;
-    QPointF viewPoint = transform().map(pos);
-
-    if (isRightToLeft())
-    {
-        qint64 horizontal = 0;
-        horizontal += horizontalScrollBar()->minimum();
-        horizontal += horizontalScrollBar()->maximum();
-        horizontal -= int(viewPoint.x() - width / 2.0);
-        horizontalScrollBar()->setValue(horizontal);
-    }
-    else
-    {
-        horizontalScrollBar()->setValue(int(viewPoint.x() - width / 2.0));
-    }
-
-    verticalScrollBar()->setValue(int(viewPoint.y() - obscuredHeight - (height / 2.0)));
+    setTransform(getTransformWithNoScaling().scale(value, value));
 }
 
-void QVGraphicsView::centerOn(qreal x, qreal y)
+QTransform QVGraphicsView::getTransformWithNoScaling() const
 {
-    centerOn(QPointF(x, y));
-}
-
-void QVGraphicsView::centerOn(const QGraphicsItem *item)
-{
-    centerOn(item->sceneBoundingRect().center());
+    const QRectF unityRect = transform().mapRect(QRectF(0, 0, 1, 1));
+    return transform().scale(1.0 / unityRect.width(), 1.0 / unityRect.height());
 }
 
 void QVGraphicsView::settingsUpdated()
@@ -693,8 +573,10 @@ void QVGraphicsView::settingsUpdated()
 
     //scaling
     isScalingEnabled = settingsManager.getBoolean("scalingenabled");
-    if (!isScalingEnabled)
-        makeUnscaled();
+    if (isScalingEnabled)
+        expensiveScaleTimer->start();
+    else
+        removeExpensiveScaling();
 
     //scaling2
     if (!isScalingEnabled)
@@ -706,7 +588,7 @@ void QVGraphicsView::settingsUpdated()
     cropMode = settingsManager.getInteger("cropmode");
 
     //scalefactor
-    scaleFactor = settingsManager.getInteger("scalefactor")*0.01+1;
+    zoomMultiplier = 1.0 + (settingsManager.getInteger("scalefactor") / 100.0);
 
     //resize past actual size
     isPastActualSizeEnabled = settingsManager.getBoolean("pastactualsizeenabled");
@@ -720,8 +602,9 @@ void QVGraphicsView::settingsUpdated()
     //loop folders
     isLoopFoldersEnabled = settingsManager.getBoolean("loopfoldersenabled");
 
-    if (getCurrentFileDetails().isPixmapLoaded)
-        resetScale();
+    // End of settings variables
+
+    zoomToFit();
 }
 
 void QVGraphicsView::closeImage()
@@ -744,7 +627,21 @@ void QVGraphicsView::setSpeed(const int &desiredSpeed)
     imageCore.setSpeed(desiredSpeed);
 }
 
-void QVGraphicsView::rotateImage(int rotation)
+void QVGraphicsView::rotateImage(const int relativeAngle)
 {
-    imageCore.rotateImage(rotation);
+    const QTransform t = transform();
+    const bool isMirroredOrFlipped = t.isRotating() ? (t.m12() < 0 == t.m21() < 0) : (t.m11() < 0 != t.m22() < 0);
+    rotate(relativeAngle * (isMirroredOrFlipped ? -1 : 1));
+}
+
+void QVGraphicsView::mirrorImage()
+{
+    const int rotateCorrection = transform().isRotating() ? -1 : 1;
+    scale(-1 * rotateCorrection, 1 * rotateCorrection);
+}
+
+void QVGraphicsView::flipImage()
+{
+    const int rotateCorrection = transform().isRotating() ? -1 : 1;
+    scale(1 * rotateCorrection, -1 * rotateCorrection);
 }

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -82,6 +82,8 @@ protected:
 
     void resizeEvent(QResizeEvent *event) override;
 
+    void paintEvent(QPaintEvent *event) override;
+
     void dropEvent(QDropEvent *event) override;
 
     void dragEnterEvent(QDragEnterEvent *event) override;
@@ -110,6 +112,10 @@ protected:
 
     QTransform getTransformWithNoScaling() const;
 
+    qreal getDpiAdjustment() const;
+
+    void handleDpiAdjustmentChange();
+
 private slots:
     void animatedFrameChanged(QRect rect);
 
@@ -128,10 +134,12 @@ private:
     bool isScrollZoomsEnabled;
     bool isLoopFoldersEnabled;
     bool isCursorZoomEnabled;
+    bool isOneToOnePixelSizingEnabled;
     int cropMode;
     qreal zoomMultiplier;
 
     qreal zoomLevel;
+    qreal appliedDpiAdjustment;
     qreal appliedExpensiveScaleZoomLevel;
     QPoint lastZoomEventPos;
     QPointF lastZoomRoundingError;

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -66,6 +66,7 @@ public:
     const QVImageCore::FileDetails& getCurrentFileDetails() const { return imageCore.getCurrentFileDetails(); }
     const QPixmap& getLoadedPixmap() const { return imageCore.getLoadedPixmap(); }
     const QMovie& getLoadedMovie() const { return imageCore.getLoadedMovie(); }
+    qreal getZoomLevel() const { return zoomLevel; }
 
     int getFitOverscan() const { return fitOverscan; }
 
@@ -73,6 +74,8 @@ signals:
     void cancelSlideshow();
 
     void fileChanged();
+
+    void zoomLevelChanged();
 
 protected:
     void wheelEvent(QWheelEvent *event) override;
@@ -137,5 +140,6 @@ private:
     QVImageCore imageCore { this };
 
     QTimer *expensiveScaleTimer;
+    QTimer *emitZoomLevelChangedTimer;
 };
 #endif // QVGRAPHICSVIEW_H

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -91,23 +91,15 @@ public:
     void setPaused(bool desiredState);
     void setSpeed(int desiredSpeed);
 
-    void rotateImage(int rotation);
-    QImage matchCurrentRotation(const QImage &imageToRotate);
-    QPixmap matchCurrentRotation(const QPixmap &pixmapToRotate);
-
-    QPixmap scaleExpensively(const int desiredWidth, const int desiredHeight);
     QPixmap scaleExpensively(const QSizeF desiredSize);
 
     //returned const reference is read-only
     const QPixmap& getLoadedPixmap() const {return loadedPixmap; }
     const QMovie& getLoadedMovie() const {return loadedMovie; }
     const FileDetails& getCurrentFileDetails() const {return currentFileDetails; }
-    int getCurrentRotation() const {return currentRotation; }
 
 signals:
     void animatedFrameChanged(QRect rect);
-
-    void updateLoadedPixmapItem();
 
     void fileChanged();
 
@@ -120,7 +112,6 @@ private:
     QMovie loadedMovie;
 
     FileDetails currentFileDetails;
-    int currentRotation;
 
     QFutureWatcher<ReadData> loadFutureWatcher;
 

--- a/src/qvoptionsdialog.cpp
+++ b/src/qvoptionsdialog.cpp
@@ -170,6 +170,8 @@ void QVOptionsDialog::syncSettings(bool defaults, bool makeConnections)
     syncCheckbox(ui->scrollZoomsCheckbox, "scrollzoomsenabled", defaults, makeConnections);
     // cursorzoom
     syncCheckbox(ui->cursorZoomCheckbox, "cursorzoom", defaults, makeConnections);
+    // onetoonepixelsizing
+    syncCheckbox(ui->oneToOnePixelSizingCheckbox, "onetoonepixelsizing", defaults, makeConnections);
     // cropmode
     syncComboBox(ui->cropModeComboBox, "cropmode", defaults, makeConnections);
     // pastactualsizeenabled

--- a/src/qvoptionsdialog.ui
+++ b/src/qvoptionsdialog.ui
@@ -349,6 +349,16 @@
         </widget>
        </item>
        <item row="7" column="1">
+        <widget class="QCheckBox" name="oneToOnePixelSizingCheckbox">
+         <property name="text">
+          <string>Zoom level is relative to screen pixels</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -361,7 +371,7 @@
          </property>
         </spacer>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QCheckBox" name="pastActualSizeCheckbox">
          <property name="toolTip">
           <string>Stop the image from going past its actual size when resizing the window - you can still zoom past it though</string>
@@ -374,7 +384,7 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QComboBox" name="cropModeComboBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -402,7 +412,7 @@
          </item>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="cropModeLabel">
          <property name="toolTip">
           <string>Ignores select sides of an image when fitting to window (some sides will extend beyond the window boundaries)</string>
@@ -438,7 +448,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <spacer name="horizontalSpacer_9">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -451,14 +461,14 @@
          </property>
         </spacer>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="colorSpaceConversionLabel">
          <property name="text">
           <string>Color space conversion:</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QComboBox" name="colorSpaceConversionComboBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -164,6 +164,12 @@ void SettingsManager::initializeSettingsLibrary()
     settingsLibrary.insert("scalefactor", {25, {}});
     settingsLibrary.insert("scrollzoomsenabled", {true, {}});
     settingsLibrary.insert("cursorzoom", {true, {}});
+#ifdef Q_OS_MACOS
+    // Usually not desired due to the way macOS does DPI scaling
+    settingsLibrary.insert("onetoonepixelsizing", {false, {}});
+#else
+    settingsLibrary.insert("onetoonepixelsizing", {true, {}});
+#endif
     settingsLibrary.insert("cropmode", {0, {}});
     settingsLibrary.insert("pastactualsizeenabled", {true, {}});
     settingsLibrary.insert("colorspaceconversion", {1, {}});


### PR DESCRIPTION
Slightly less ambitious version of the graphicsview-rewrite branch. I actually started with that branch, made some minor fixes, squash merged everything down, removed anything related to constrained positioning, removed anything related to navigation/resize resets zoom, and then broke it back down into more manageable commits. In terms of operation/feel, this should function the same as currently, aside from Original Size which now simply sets the zoom level to 100% instead of functioning like a quasi-toggle / different mode.

* Closes #645.
* Fixes #627.
* Fixes #374.
* Fixes some other unreported issues related to window sizing, and rotate appearing to go in the opposite direction when applied on a mirrored or flipped image.