### PR TITLE
Fix inability to load certain JPG files

### DIFF
--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -126,7 +126,6 @@ void QVImageCore::loadFile(const QString &fileName, bool isReloading)
 QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColorSpace &targetColorSpace)
 {
     QImageReader imageReader;
-    imageReader.setDecideFormatFromContent(true);
     imageReader.setAutoTransform(true);
 
     imageReader.setFileName(fileName);


### PR DESCRIPTION
Fixes #698. The code was setting to `setDecideFormatFromContent` to `true`, which based on my understanding means that Qt isn't allowed to use the file's extension as a hint to pick the proper decoder. This made it scan all decoders, and the RAW decoder is claiming it can decode the file for some reason. This setting is not to be confused with `setAutoDetectImageFormat` which is enabled by default, so in case a file is missing an extension, it will still open properly (except for these rare cases where the auto detection gets confused), or even if it has the incorrect extension, Qt will realize that the hint provided by the filename extension is incorrect and fall back to querying all decoders.

The code enabling `setDecideFormatFromContent` was originally added in https://github.com/jurplel/qView/commit/97f108906f7c8517f43334b09443df56e191d567 which was supposedly to fix #28, but I have no problem opening a JPG renamed as PNG even after this change, so maybe a different part of that commit was responsible for fixing it, or Qt improved their image loading since then (it works fine for me even with the legacy 5.15.2 builds by the way).