### PR TITLE
macOS: Fix crash on exit

### DIFF
--- a/src/actionmanager.cpp
+++ b/src/actionmanager.cpp
@@ -542,9 +542,13 @@ void ActionManager::actionTriggered(QAction *triggeredAction, MainWindow *releva
     auto key = triggeredAction->data().toStringList().first();
 
     if (key == "quit") {
-        if (relevantWindow) // if a window was passed
-            relevantWindow->close(); // close it so geometry is saved
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        // Workaround to allow for a graceful exit (e.g. fire window close events)
+        // since QCoreApplication::quit can't accomplish this prior to Qt 6
+        qGuiApp->postEvent(qGuiApp, new QEvent(QEvent::Quit));
+#else
         QCoreApplication::quit();
+#endif
     } else if (key == "newwindow") {
         qvApp->newWindow();
     } else if (key == "open") {


### PR DESCRIPTION
Fixes #717 which started happening to me also after updating to macOS 15, both with the 6.1 release as well as the latest nightly build. I believe it fixes #635 too since the stack traces of my recent crashes look almost identical to what's posted in that issue.

I'm not entirely sure why it was happening, but I know that commenting out the `close()` call on the window fixed it, so I suspect that since `QCoreApplication::quit()` itself tries to close all open windows (in Qt 6 at least), it couldn't handle that one of the windows was already in the process of being closed (I'm assuming `close()` isn't done immediately and needs certain parts to happen through the event loop).

So why were we calling `close()` on the window if `QCoreApplication::quit()` already does it? As I hinted, this graceful quit behavior was introduced in Qt 6, so `close()` was indeed necessary but only for Qt 5. But I actually found a better workaround for Qt 5 which not only handles closing all the windows, but also emits signals like `QCoreApplication::aboutToQuit`. This might be needed in the future if you plan to support session restoration in the legacy macOS build, hence why I went with it.