### PR TITLE
Add additional file extensions for HEIC/HEIF

### DIFF
--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -362,12 +362,24 @@ void QVApplication::defineFilterLists()
         filterString += "*" + fileExtension + " ";
         fileExtensionList << fileExtension;
 
-        // If we support jpg, we actually support the jfif, jfi, and jpe file extensions too almost certainly.
+        // Register additional file extensions that decoders support but don't advertise
         if (fileExtension == ".jpg")
         {
             filterList << "*.jpe" << "*.jfi" << "*.jfif";
             filterString += "*.jpe *.jfi *.jfif ";
             fileExtensionList << ".jpe" << ".jfi" << ".jfif";
+        }
+        else if (fileExtension == ".heic")
+        {
+            filterList << "*.heics";
+            filterString += "*.heics ";
+            fileExtensionList << ".heics";
+        }
+        else if (fileExtension == ".heif")
+        {
+            filterList << "*.heifs" << "*.hif";
+            filterString += "*.heifs *.hif ";
+            fileExtensionList << ".heifs" << ".hif";
         }
     }
     filterString.chop(1);

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -347,8 +347,12 @@ void QVApplication::defineFilterLists()
     const auto &byteArrayFormats = QImageReader::supportedImageFormats();
 
     auto filterString = tr("Supported Images") + " (";
-    filterList.reserve(byteArrayFormats.size()-1);
     fileExtensionList.reserve(byteArrayFormats.size()-1);
+
+    const auto addExtension = [&](const QString &extension) {
+        filterString += "*" + extension + " ";
+        fileExtensionList << extension;
+    };
 
     // Build the filterlist, filterstring, and filterregexplist in one loop
     for (const auto &byteArray : byteArrayFormats)
@@ -358,28 +362,25 @@ void QVApplication::defineFilterLists()
         if (fileExtension == ".pdf")
             continue;
 
-        filterList << "*" + fileExtension;
-        filterString += "*" + fileExtension + " ";
-        fileExtensionList << fileExtension;
+        addExtension(fileExtension);
 
         // Register additional file extensions that decoders support but don't advertise
         if (fileExtension == ".jpg")
         {
-            filterList << "*.jpe" << "*.jfi" << "*.jfif";
-            filterString += "*.jpe *.jfi *.jfif ";
-            fileExtensionList << ".jpe" << ".jfi" << ".jfif";
+            addExtension(".jpe");
+            addExtension(".jfi");
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+            addExtension(".jfif");
+#endif
         }
         else if (fileExtension == ".heic")
         {
-            filterList << "*.heics";
-            filterString += "*.heics ";
-            fileExtensionList << ".heics";
+            addExtension(".heics");
         }
         else if (fileExtension == ".heif")
         {
-            filterList << "*.heifs" << "*.hif";
-            filterString += "*.heifs *.hif ";
-            fileExtensionList << ".heifs" << ".hif";
+            addExtension(".heifs");
+            addExtension(".hif");
         }
     }
     filterString.chop(1);

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -63,8 +63,6 @@ public:
 
     QMenuBar *getMenuBar() const {  return menuBar; }
 
-    const QStringList &getFilterList() const { return filterList; }
-
     const QStringList &getNameFilterList() const { return nameFilterList; }
 
     const QStringList &getFileExtensionList() const { return fileExtensionList; }
@@ -87,7 +85,6 @@ private:
 
     QMenuBar *menuBar;
 
-    QStringList filterList;
     QStringList nameFilterList;
     QStringList fileExtensionList;
     QStringList mimeTypeNameList;


### PR DESCRIPTION
Fixes #702. Added .hif extension which is non-standard but used by Canon cameras. I found a sample image [here](https://github.com/strukturag/libheif/issues/219) and was able to load it.

Also added .heics/.heifs which are "sequence" variants (i.e. animated); we can at least display them as stills but the decoders don't support animation. I found some [sample .heics files](https://gitlab.com/lobau/heics2gif/-/tree/main/samples?ref_type=heads) which the iPhone apparently produces for its "Live Stickers" feature.