### PR TITLE
Windows: Fix ICC profile detection not working per-monitor

### DIFF
--- a/src/qvwin32functions.cpp
+++ b/src/qvwin32functions.cpp
@@ -165,22 +165,31 @@ QByteArray QVWin32Functions::getIccProfileForWindow(const QWindow *window)
 {
     QByteArray result;
     const HWND hWnd = reinterpret_cast<HWND>(window->winId());
-    const HDC hDC = GetDC(hWnd);
-    if (hDC)
+    const HMONITOR hMonitor = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+    if (hMonitor)
     {
-        WCHAR profilePathBuff[MAX_PATH];
-        DWORD profilePathSize = MAX_PATH;
-        if (GetICMProfileW(hDC, &profilePathSize, profilePathBuff))
+        MONITORINFOEXW monitorInfo;
+        monitorInfo.cbSize = sizeof(MONITORINFOEXW);
+        if (GetMonitorInfoW(hMonitor, &monitorInfo))
         {
-            QString profilePath = QString::fromWCharArray(profilePathBuff);
-            QFile file(profilePath);
-            if (file.open(QIODevice::ReadOnly))
+            const HDC hDC = CreateICW(monitorInfo.szDevice, monitorInfo.szDevice, NULL, NULL);
+            if (hDC)
             {
-                result = file.readAll();
-                file.close();
+                WCHAR profilePathBuff[MAX_PATH];
+                DWORD profilePathSize = MAX_PATH;
+                if (GetICMProfileW(hDC, &profilePathSize, profilePathBuff))
+                {
+                    QString profilePath = QString::fromWCharArray(profilePathBuff);
+                    QFile file(profilePath);
+                    if (file.open(QIODevice::ReadOnly))
+                    {
+                        result = file.readAll();
+                        file.close();
+                    }
+                }
+                ReleaseDC(hWnd, hDC);
             }
         }
-        ReleaseDC(hWnd, hDC);
     }
     return result;
 }


### PR DESCRIPTION
When I implemented the color space stuff, it was intended to have at least basic support for per-monitor ICC profiles. Specifically, even if it doesn't update in realtime as one drags the window to a different monitor, it should at least use the current monitor's ICC profile when loading a new image or reloading the current image. I remember testing this, but probably only on macOS, since just I discovered it wasn't working as intended on Windows. `GetDC(hWnd)` is apparently too simplistic of an approach and the result was always the same ICC profile regardless of which monitor the window was on (maybe it just returned the ICC profile for the default monitor). Even though all my monitors are the same model, I was able to test it by assigning a fake profile to one of them (this is handy for testing: [SwappedRedAndGreen.zip](https://github.com/user-attachments/files/17370410/SwappedRedAndGreen.zip)).

Recommended to review the diff with "Hide whitespace" enabled.