### PR TITLE
Fix "Error occurred opening" due to uninitialized variables

### DIFF
--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -36,8 +36,8 @@ public:
 
     struct ErrorData
     {
-        bool hasError;
-        int errorNum;
+        bool hasError = false;
+        int errorNum = 0;
         QString errorString;
     };
 


### PR DESCRIPTION
I just noticed that sometimes after launching qView without a file (i.e. no command line arguments), it would display this error with a random number:

![image](https://github.com/user-attachments/assets/3cd6ad8f-6964-4e90-9159-82f550690286)

I've only seen it happen on the 32-bit Windows build. Seems it was caused by uninitialized variables when `ErrorData` gets default-initialized.