### PR TITLE
Bypass smooth scaling, alternate implementation

### DIFF
--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -383,7 +383,7 @@ void QVGraphicsView::animatedFrameChanged(QRect rect)
 {
     Q_UNUSED(rect)
 
-    if (isScalingEnabled)
+    if (isExpensiveScalingRequested())
     {
         scaleExpensively();
     }

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -310,6 +310,9 @@ void QVGraphicsView::zoom(qreal scaleFactor, const QPoint &pos)
 
 void QVGraphicsView::scaleExpensively()
 {
+    if (!isExpensiveScalingRequested())
+        return;
+
     // Determine if mirrored or flipped
     bool mirrored = false;
     if (transform().m11() < 0)
@@ -547,7 +550,7 @@ bool QVGraphicsView::isSmoothScalingRequested() const
 bool QVGraphicsView::isExpensiveScalingRequested() const
 {
     return getCurrentFileDetails().isPixmapLoaded && isScalingEnabled && getZoomLevel() < smoothScalingLimit &&
-        currentScale <= (isScalingTwoEnabled ? maxScalingTwoSize : 1.00001);
+        !isOriginalSize && currentScale <= (isScalingTwoEnabled ? maxScalingTwoSize : 1.00001);
 }
 
 void QVGraphicsView::fitInViewMarginless(const QRectF &rect)

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -96,6 +96,12 @@ protected:
 
     bool event(QEvent *event) override;
 
+    qreal getZoomLevel() const;
+
+    bool isSmoothScalingRequested() const;
+
+    bool isExpensiveScalingRequested() const;
+
     void fitInViewMarginless(const QRectF &rect);
     void fitInViewMarginless(const QGraphicsItem *item);
 
@@ -105,6 +111,7 @@ protected:
 
     void centerOn(const QGraphicsItem *item);
 
+    void handleSmoothScalingChange();
 
 private slots:
     void animatedFrameChanged(QRect rect);
@@ -118,6 +125,7 @@ private:
 
     QGraphicsPixmapItem *loadedPixmapItem;
 
+    qreal smoothScalingLimit = 3.0;
     bool isFilteringEnabled;
     bool isScalingEnabled;
     bool isScalingTwoEnabled;


### PR DESCRIPTION
Based on the original graphics view code. Threshold is hard-coded for testing (0 means no limit by the way). UI is left as an exercise for the reader. Barely tested.