### PR TITLE
Fix crash on exit if image load or preload is in progress

### DIFF
--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -75,9 +75,15 @@ public:
 
     ActionManager &getActionManager() { return actionManager; }
 
+    bool getIsApplicationQuitting() const;
+
     static qreal getPerceivedBrightness(const QColor &color);
 
+protected slots:
+    void onAboutToQuit();
+
 private:
+    std::atomic<bool> isApplicationQuitting {false};
 
     QList<MainWindow*> lastActiveWindows;
 

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -130,6 +130,9 @@ void QVImageCore::loadFile(const QString &fileName, bool isReloading)
 
 QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColorSpace &targetColorSpace)
 {
+    if (qvApp->getIsApplicationQuitting())
+        return {};
+
     QImageReader imageReader;
     imageReader.setAutoTransform(true);
 
@@ -151,6 +154,9 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
         readImage = imageReader.read();
     }
 
+    if (qvApp->getIsApplicationQuitting())
+        return {};
+
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
     // Work around Qt ICC profile parsing bug
     if (!readImage.colorSpace().isValid() && !readImage.colorSpace().iccProfile().isEmpty())
@@ -170,6 +176,9 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
     if (targetColorSpace.isValid() && readImage.colorSpace() != targetColorSpace)
         readImage.convertToColorSpace(targetColorSpace);
 #endif
+
+    if (qvApp->getIsApplicationQuitting())
+        return {};
 
     QPixmap readPixmap = QPixmap::fromImage(readImage);
     QFileInfo fileInfo(fileName);

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -130,11 +130,6 @@ void QVImageCore::loadFile(const QString &fileName, bool isReloading)
 
 QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColorSpace &targetColorSpace)
 {
-    // Default initialize return struct now. This is important in case the application starts
-    // closing while we're loading an image. Once that happens it's impossible to construct
-    // even a null pixmap due to Qt requiring that an application instance exists.
-    ReadData readData;
-
     QImageReader imageReader;
     imageReader.setAutoTransform(true);
 
@@ -156,9 +151,6 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
         readImage = imageReader.read();
     }
 
-    if (QCoreApplication::closingDown())
-        return readData;
-
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
     // Work around Qt ICC profile parsing bug
     if (!readImage.colorSpace().isValid() && !readImage.colorSpace().iccProfile().isEmpty())
@@ -179,11 +171,17 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
         readImage.convertToColorSpace(targetColorSpace);
 #endif
 
-    if (QCoreApplication::closingDown())
-        return readData;
-
     QPixmap readPixmap = QPixmap::fromImage(readImage);
     QFileInfo fileInfo(fileName);
+
+    ReadData readData = {
+        readPixmap,
+        fileInfo.absoluteFilePath(),
+        fileInfo.size(),
+        imageReader.size(),
+        targetColorSpace,
+        {}
+    };
 
     if (readPixmap.isNull())
     {
@@ -193,12 +191,6 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
             imageReader.errorString()
         };
     }
-
-    readData.pixmap = std::move(readPixmap);
-    readData.absoluteFilePath = fileInfo.absoluteFilePath();
-    readData.fileSize = fileInfo.size();
-    readData.imageSize = imageReader.size();
-    readData.targetColorSpace = targetColorSpace;
 
     return readData;
 }

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -130,6 +130,11 @@ void QVImageCore::loadFile(const QString &fileName, bool isReloading)
 
 QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColorSpace &targetColorSpace)
 {
+    // Default initialize return struct now. This is important in case the application starts
+    // closing while we're loading an image. Once that happens it's impossible to construct
+    // even a null pixmap due to Qt requiring that an application instance exists.
+    ReadData readData;
+
     QImageReader imageReader;
     imageReader.setAutoTransform(true);
 
@@ -151,6 +156,9 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
         readImage = imageReader.read();
     }
 
+    if (QCoreApplication::closingDown())
+        return readData;
+
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
     // Work around Qt ICC profile parsing bug
     if (!readImage.colorSpace().isValid() && !readImage.colorSpace().iccProfile().isEmpty())
@@ -171,17 +179,11 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
         readImage.convertToColorSpace(targetColorSpace);
 #endif
 
+    if (QCoreApplication::closingDown())
+        return readData;
+
     QPixmap readPixmap = QPixmap::fromImage(readImage);
     QFileInfo fileInfo(fileName);
-
-    ReadData readData = {
-        readPixmap,
-        fileInfo.absoluteFilePath(),
-        fileInfo.size(),
-        imageReader.size(),
-        targetColorSpace,
-        {}
-    };
 
     if (readPixmap.isNull())
     {
@@ -191,6 +193,12 @@ QVImageCore::ReadData QVImageCore::readFile(const QString &fileName, const QColo
             imageReader.errorString()
         };
     }
+
+    readData.pixmap = std::move(readPixmap);
+    readData.absoluteFilePath = fileInfo.absoluteFilePath();
+    readData.fileSize = fileInfo.size();
+    readData.imageSize = imageReader.size();
+    readData.targetColorSpace = targetColorSpace;
 
     return readData;
 }

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -61,7 +61,7 @@ public:
     {
         QPixmap pixmap;
         QString absoluteFilePath;
-        qint64 fileSize;
+        qint64 fileSize = 0;
         QSize imageSize;
         QColorSpace targetColorSpace;
         ErrorData errorData;


### PR DESCRIPTION
Fixes #750. Qt is doing [validation](https://github.com/qt/qtbase/blob/6.8.2/src/gui/image/qpixmap.cpp#L51) from every `QPixmap` constructor (even parameterless i.e. null pixmap construction, or when shallow copying). Only way I could figure to work around it is to make sure the application isn't closing and hope that's still the case when `QPixmap`'s constructor runs (there's no way to catch/cancel a qFatal as far as I understand). And using `std::move` so the copy constructor isn't called.