### PR TITLE
Ignore wheel events from touchpads on Qt6+

### DIFF
--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -155,11 +155,17 @@ bool QVGraphicsView::event(QEvent *event)
 
 void QVGraphicsView::wheelEvent(QWheelEvent *event)
 {
-    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (event->device()->type() == QInputDevice::DeviceType::TouchPad || event->device()->type() == QInputDevice::DeviceType::TouchScreen) {
+        return;
+    }
+#endif
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     const QPoint eventPos = event->position().toPoint();
-    #else
+#else
     const QPoint eventPos = event->pos();
-    #endif
+#endif
 
     //Basically, if you are holding ctrl then it scrolls instead of zooms (the shift bit is for horizontal scrolling)
     bool willZoom = isScrollZoomsEnabled;


### PR DESCRIPTION
An annoyance of mine since I implemented trackpad gestures was the fact that one had to manually change a setting to make them work properly.

This PR fixes that on Qt6+