### PR TITLE
macOS: Fix “Open With” menu's enabled state not being scoped per window

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -428,7 +428,7 @@ void MainWindow::disableActions()
         }
     }
 
-    const auto &openWithMenus = qvApp->getActionManager().getAllClonesOfMenu("openwith");
+    const auto &openWithMenus = qvApp->getActionManager().getAllClonesOfMenu("openwith", this);
     for (const auto &menu : openWithMenus)
     {
         menu->setEnabled(getCurrentFileDetails().isPixmapLoaded);


### PR DESCRIPTION
Fixes an issue in macOS where if you have multiple windows open, and one of them "closes" its file (e.g. after encountering an image load error), the Open With menu gets disabled for all windows, not just the affected window.