### PR TITLE
CI: macOS build fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,11 +86,12 @@ jobs:
         shell: pwsh
         run: |
           if ("${{ matrix.skipPlugins }}" -ne "true") {
-            Invoke-Expression "& 'dist/scripts/download-plugins.ps1'"
+            & dist/scripts/download-plugins.ps1
           }
           if ($IsWindows) {
-            Invoke-Expression "& 'dist/scripts/windeployqt.ps1' ${{ env.buildNumString }}"
+            & dist/scripts/windeployqt.ps1 ${{ env.buildNumString }}
           } elseif ($IsMacOS) {
+            & dist/scripts/macinstallcert.ps1
             bash dist/scripts/macdeploy.sh ${{ env.buildNumString }}
           } else {
             bash dist/scripts/linuxdeployqt.sh ${{ env.buildNumString }}

--- a/dist/scripts/build.ps1
+++ b/dist/scripts/build.ps1
@@ -5,6 +5,9 @@ param
     $Prefix = "/usr"
 )
 
+$qtVersion = [version](qmake -query QT_VERSION)
+Write-Host "Detected Qt version $qtVersion"
+
 if ($IsWindows) {
     dist/scripts/vcvars.ps1
 } elseif ($IsMacOS) {

--- a/dist/scripts/macdeploy.sh
+++ b/dist/scripts/macdeploy.sh
@@ -7,24 +7,6 @@ else
     VERSION=${VERSION: -3}
 fi
 
-if [[ -n "$APPLE_DEVID_APP_CERT_DATA" ]]; then
-    CODESIGN_CERT_PATH=$RUNNER_TEMP/codesign.p12
-    KEYCHAIN_PATH=$RUNNER_TEMP/codesign.keychain-db
-    KEYCHAIN_PASS=$(uuidgen)
-
-    echo -n "$APPLE_DEVID_APP_CERT_DATA" | base64 --decode -o "$CODESIGN_CERT_PATH"
-
-    security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
-    security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
-    security import "$CODESIGN_CERT_PATH" -P "$APPLE_DEVID_APP_CERT_PASS" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-    security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
-    security list-keychains -d user -s "$KEYCHAIN_PATH"
-
-    CODESIGN_CERT_NAME=$(openssl pkcs12 -in "$CODESIGN_CERT_PATH" -passin pass:"$APPLE_DEVID_APP_CERT_PASS" -nokeys -clcerts -info 2>&1 | openssl x509 -noout -subject -nameopt multiline | grep commonName | awk -F'= ' '{print $2}')
-else
-    CODESIGN_CERT_NAME=-
-fi
-
 cd bin
 
 echo "Running macdeployqt"

--- a/dist/scripts/macinstallcert.ps1
+++ b/dist/scripts/macinstallcert.ps1
@@ -1,0 +1,25 @@
+#!/usr/bin/env pwsh
+
+using namespace System.Security.Cryptography.X509Certificates
+
+if ($env:APPLE_DEVID_APP_CERT_DATA) {
+    $certPath = Join-Path $env:RUNNER_TEMP 'codesign.p12'
+    $keychainPath = Join-Path $env:RUNNER_TEMP 'codesign.keychain-db'
+    $keychainPass = [Guid]::NewGuid().ToString()
+
+    [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:APPLE_DEVID_APP_CERT_DATA))
+
+    & security create-keychain -p $keychainPass $keychainPath
+    & security unlock-keychain -p $keychainPass $keychainPath
+    & security import $certPath -P $env:APPLE_DEVID_APP_CERT_PASS -A -t cert -f pkcs12 -k $keychainPath
+    & security set-key-partition-list -S apple-tool:,apple: -s -k $keychainPass $keychainPath
+    & security list-keychains -d user -s $keychainPath
+
+    $cert = New-Object X509Certificate2($certPath, $env:APPLE_DEVID_APP_CERT_PASS)
+    $certName = $cert.GetNameInfo([X509NameType]::SimpleName, $false)
+}
+else {
+    $certName = '-'
+}
+
+[Environment]::SetEnvironmentVariable('CODESIGN_CERT_NAME', $certName)


### PR DESCRIPTION
* On the `macos-26` runner, if you were to try building with Apple signing/notarization enabled, the part of the build script that fetches the certificate name fails I believe due to the `openssl` output changing in newer versions. I moved the certificate installation logic to a PowerShell script which allows the certificate name to be obtained more easily/robustly. A signed/notarized test run [completed successfully](https://github.com/jdpurcell/qView/actions/runs/18434680651) (using Qt 6.9.3 due to #771).
* The non-legacy builds have been showing a non-fatal error `xcode-select: error: invalid developer directory '/Applications/Xcode_14.3.1.app'` due to an undefined `$qtVersion` variable (oops that was my fault).