### PR TITLE
Add JSON IPC current path query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(PROJECT_SOURCES
     src/qvwelcomedialog.cpp
     src/qvinfodialog.cpp
     src/qvimagecore.cpp
+    src/qvipcserver.cpp
     src/qvshortcutdialog.cpp
     src/actionmanager.cpp
     src/settingsmanager.cpp
@@ -77,6 +78,7 @@ set(PROJECT_HEADERS
     src/qvwelcomedialog.h
     src/qvinfodialog.h
     src/qvimagecore.h
+    src/qvipcserver.h
     src/qvshortcutdialog.h
     src/actionmanager.h
     src/settingsmanager.h

--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@
 <p align=center>
     <img alt="Screenshot" src="https://interversehq.com/qview/assets/img/screenshot3.png">
 </p>
+
+## IPC
+
+qView can open an opt-in JSON IPC socket with `--ipc-server`. See
+[docs/ipc.md](docs/ipc.md) for the current file path query and a Zsh helper.

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -1,0 +1,94 @@
+# qView IPC
+
+qView can open an opt-in local IPC socket for newline-delimited JSON messages.
+The server is disabled by default.
+
+## Starting the Server
+
+Start qView with `--ipc-server`:
+
+```sh
+qview --ipc-server
+```
+
+Without a value, the Unix socket path defaults to:
+
+```sh
+${TMPDIR:-/tmp}/qview-${UID}.sock
+```
+
+You can pass an explicit socket path either with `=` or as the following
+argument:
+
+```sh
+qview --ipc-server=/tmp/qview.sock
+qview --ipc-server /tmp/qview.sock
+```
+
+If you need to pass a file path after the default socket flag, put the file
+before the flag:
+
+```sh
+qview image.jpg --ipc-server
+```
+
+## Messages
+
+Each request and response is one compact JSON object followed by a newline.
+
+Current file path request:
+
+```json
+{"method":"currentFilePath"}
+```
+
+Success response:
+
+```json
+{"ok":true,"path":"/absolute/current/file.jpg"}
+```
+
+Failure response when no file is open:
+
+```json
+{"ok":false,"error":"no_current_file"}
+```
+
+Unknown methods return:
+
+```json
+{"ok":false,"error":"unknown_method"}
+```
+
+Invalid JSON returns:
+
+```json
+{"ok":false,"error":"invalid_json"}
+```
+
+## Zsh Example
+
+`qview-path-get` prints the current file path and returns non-zero if qView is
+not reachable, the response is malformed, or no current file exists.
+
+```zsh
+qview-path-get() {
+  emulate -L zsh
+  local socket="${1:-${QVIEW_IPC_SOCKET:-${TMPDIR:-/tmp/}qview-${UID}.sock}}"
+  local response
+
+  response=$(
+    printf '%s\n' '{"method":"currentFilePath"}' |
+      socat - "UNIX-CONNECT:${socket}" 2>/dev/null
+  ) || return 1
+
+  local ok path
+  ok=$(printf '%s\n' "$response" | jq -er '.ok') || return 1
+  [[ "$ok" == true ]] || return 1
+
+  path=$(printf '%s\n' "$response" | jq -er '.path // empty') || return 1
+  [[ -n "$path" ]] || return 1
+
+  print -r -- "$path"
+}
+```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include "qvapplication.h"
+#include "qvipcserver.h"
 #include "qvwin32functions.h"
 
 #include <QCommandLineParser>
@@ -14,26 +15,29 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationVersion(QString::number(VERSION));
     QVApplication app(argc, argv);
 
+#if defined Q_OS_WIN && WIN32_LOADED && QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
+    QStringList arguments = QVWin32Functions::getCommandLineArgs();
+#else
+    QStringList arguments = app.arguments();
+#endif
+    const auto ipcServerOption = QVIPCServer::extractServerOption(&arguments);
+
     QCommandLineParser parser;
     parser.addHelpOption();
     parser.addVersionOption();
+    parser.addOption(QCommandLineOption(
+            "ipc-server",
+            QObject::tr("Open a JSON IPC socket. With no value, uses the default per-user socket. "
+                        "Use --ipc-server=<socket> or --ipc-server <socket> to set it.")));
     parser.addPositionalArgument(QObject::tr("file"), QObject::tr("The file to open."));
-#if defined Q_OS_WIN && WIN32_LOADED && QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
-    // Workaround for unicode characters getting mangled in certain cases. To support unicode
-    // arguments on Windows, QCoreApplication normally ignores argv and gets them from the Windows
-    // API instead. But this only happens if it thinks argv hasn't been modified prior to being
-    // passed into QCoreApplication's constructor. Certain characters like U+2033 (double prime) get
-    // converted differently in argv versus the value Qt is comparing with (__argv). This makes Qt
-    // incorrectly think the data was changed, and it skips fetching unicode arguments from the API.
-    // https://bugreports.qt.io/browse/QTBUG-125380
-    parser.process(QVWin32Functions::getCommandLineArgs());
-#else
-    parser.process(app);
-#endif
+    parser.process(arguments);
 
     auto *window = QVApplication::newWindow();
     if (!parser.positionalArguments().isEmpty())
         QVApplication::openFile(window, parser.positionalArguments().constFirst(), true);
+
+    if (ipcServerOption.enabled)
+        app.startIpcServer(ipcServerOption.serverName);
 
     return QApplication::exec();
 }

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -1,6 +1,7 @@
 #include "qvapplication.h"
 #include "qvoptionsdialog.h"
 #include "qvcocoafunctions.h"
+#include "qvipcserver.h"
 #include "updatechecker.h"
 
 #include <QFileOpenEvent>
@@ -370,6 +371,48 @@ void QVApplication::defineFilterLists()
     // Build name filter list for file dialogs
     nameFilterList << filterString;
     nameFilterList << tr("All Files") + " (*)";
+}
+
+bool QVApplication::startIpcServer(const QString &serverName)
+{
+    ipcServer.reset(new QVIPCServer(this));
+    if (ipcServer->listen(serverName)) {
+        qInfo() << "qView IPC server listening on" << ipcServer->serverName();
+        return true;
+    }
+
+    qWarning() << "Could not listen on qView IPC server" << serverName;
+    ipcServer.reset();
+    return false;
+}
+
+QString QVApplication::currentFilePath() const
+{
+    auto pathForWindow = [](const MainWindow *window) {
+        if (!window)
+            return QString();
+
+        const auto &fileDetails = window->getCurrentFileDetails();
+        if (!fileDetails.isLoadRequested)
+            return QString();
+
+        return fileDetails.fileInfo.absoluteFilePath();
+    };
+
+    for (const auto &window : lastActiveWindows) {
+        const QString path = pathForWindow(window);
+        if (!path.isEmpty())
+            return path;
+    }
+
+    const auto topLevelWidgets = QApplication::topLevelWidgets();
+    for (const auto &widget : topLevelWidgets) {
+        const QString path = pathForWindow(qobject_cast<MainWindow *>(widget));
+        if (!path.isEmpty())
+            return path;
+    }
+
+    return QString();
 }
 
 void QVApplication::ensureFontLoaded(const QString &path)

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -11,6 +11,7 @@
 #include "qvwelcomedialog.h"
 
 #include <QApplication>
+#include <QScopedPointer>
 #include <QRegularExpression>
 
 #if defined(qvApp)
@@ -28,6 +29,8 @@
     qvApp->getSettingsManager().getDouble(SettingsManager::Setting::setting)
 #define qvGetSettingString(setting) \
     qvApp->getSettingsManager().getString(SettingsManager::Setting::setting)
+
+class QVIPCServer;
 
 class QVApplication : public QApplication
 {
@@ -87,6 +90,10 @@ public:
 
     void ensureFontLoaded(const QString &path);
 
+    bool startIpcServer(const QString &serverName);
+
+    QString currentFilePath() const;
+
     static QIcon iconFromFont(const QString &fontFamily, const QChar &codePoint, const int pixelSize, const qreal pixelRatio);
 
     static qreal getPerceivedBrightness(const QColor &color);
@@ -116,6 +123,8 @@ private:
 #endif // QV_DISABLE_ONLINE_VERSION_CHECK
 
     QSet<QString> loadedFontPaths;
+
+    QScopedPointer<QVIPCServer> ipcServer;
 };
 
 #endif // QVAPPLICATION_H

--- a/src/qvipcserver.cpp
+++ b/src/qvipcserver.cpp
@@ -1,0 +1,163 @@
+#include "qvipcserver.h"
+#include "qvapplication.h"
+
+#include <QDir>
+#include <QJsonDocument>
+#include <QLocalSocket>
+
+#ifdef Q_OS_UNIX
+#  include <unistd.h>
+#endif
+
+namespace {
+const char *bufferPropertyName = "qviewIpcBuffer";
+
+QString fallbackUserId()
+{
+#ifdef Q_OS_UNIX
+    return QString::number(getuid());
+#else
+    const QString username = qEnvironmentVariable("USERNAME");
+    return username.isEmpty() ? QStringLiteral("user") : username;
+#endif
+}
+}
+
+QVIPCServer::QVIPCServer(QVApplication *app) : QObject(app), application(app)
+{
+    connect(&localServer, &QLocalServer::newConnection, this, &QVIPCServer::acceptConnections);
+}
+
+bool QVIPCServer::listen(const QString &serverName)
+{
+    const QString name = serverName.isEmpty() ? defaultServerName() : serverName;
+    if (localServer.listen(name))
+        return true;
+
+    if (localServer.serverError() != QAbstractSocket::AddressInUseError)
+        return false;
+
+    QLocalSocket probe;
+    probe.connectToServer(name);
+    if (probe.waitForConnected(100)) {
+        probe.disconnectFromServer();
+        return false;
+    }
+
+    QLocalServer::removeServer(name);
+    return localServer.listen(name);
+}
+
+QString QVIPCServer::serverName() const
+{
+    return localServer.serverName();
+}
+
+QString QVIPCServer::defaultServerName()
+{
+#ifdef Q_OS_UNIX
+    QString socketDir = qEnvironmentVariable("TMPDIR");
+    if (socketDir.isEmpty())
+        socketDir = QDir::tempPath();
+    if (socketDir.isEmpty())
+        socketDir = QStringLiteral("/tmp");
+
+    return QDir(socketDir).absoluteFilePath(QStringLiteral("qview-%1.sock").arg(fallbackUserId()));
+#else
+    return QStringLiteral("qview-%1").arg(fallbackUserId());
+#endif
+}
+
+QVIPCServer::ServerOption QVIPCServer::extractServerOption(QStringList *arguments)
+{
+    ServerOption option;
+    if (!arguments || arguments->isEmpty())
+        return option;
+
+    for (int i = 1; i < arguments->size(); ++i) {
+        const QString argument = arguments->at(i);
+        if (argument == QStringLiteral("--ipc-server")) {
+            option.enabled = true;
+            arguments->removeAt(i);
+
+            if (i < arguments->size() && !arguments->at(i).startsWith(QLatin1Char('-'))) {
+                option.serverName = arguments->takeAt(i);
+                --i;
+            } else {
+                option.serverName = defaultServerName();
+                --i;
+            }
+        } else if (argument.startsWith(QStringLiteral("--ipc-server="))) {
+            option.enabled = true;
+            option.serverName = argument.mid(QStringLiteral("--ipc-server=").size());
+            if (option.serverName.isEmpty())
+                option.serverName = defaultServerName();
+            arguments->removeAt(i);
+            --i;
+        }
+    }
+
+    return option;
+}
+
+QJsonObject QVIPCServer::handleMessage(const QJsonObject &message, const QString &currentFilePath)
+{
+    const QString method = message.value(QStringLiteral("method")).toString();
+    if (method == QStringLiteral("currentFilePath")) {
+        if (currentFilePath.isEmpty()) {
+            return { { QStringLiteral("ok"), false },
+                     { QStringLiteral("error"), QStringLiteral("no_current_file") } };
+        }
+
+        return { { QStringLiteral("ok"), true }, { QStringLiteral("path"), currentFilePath } };
+    }
+
+    return { { QStringLiteral("ok"), false },
+             { QStringLiteral("error"), QStringLiteral("unknown_method") } };
+}
+
+void QVIPCServer::acceptConnections()
+{
+    while (auto *socket = localServer.nextPendingConnection()) {
+        socket->setParent(this);
+        connect(socket, &QLocalSocket::readyRead, this,
+                [this, socket]() { handleSocketData(socket); });
+        connect(socket, &QLocalSocket::disconnected, socket, &QLocalSocket::deleteLater);
+    }
+}
+
+void QVIPCServer::handleSocketData(QLocalSocket *socket)
+{
+    QByteArray buffer = socket->property(bufferPropertyName).toByteArray();
+    buffer.append(socket->readAll());
+
+    int newlineIndex = buffer.indexOf('\n');
+    while (newlineIndex != -1) {
+        const QByteArray line = buffer.left(newlineIndex).trimmed();
+        buffer.remove(0, newlineIndex + 1);
+
+        if (!line.isEmpty()) {
+            QJsonParseError parseError;
+            const QJsonDocument document = QJsonDocument::fromJson(line, &parseError);
+            if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+                sendResponse(socket,
+                             { { QStringLiteral("ok"), false },
+                               { QStringLiteral("error"), QStringLiteral("invalid_json") } });
+            } else {
+                sendResponse(socket,
+                             handleMessage(document.object(), application->currentFilePath()));
+            }
+        }
+
+        newlineIndex = buffer.indexOf('\n');
+    }
+
+    socket->setProperty(bufferPropertyName, buffer);
+}
+
+void QVIPCServer::sendResponse(QLocalSocket *socket, const QJsonObject &response)
+{
+    socket->write(QJsonDocument(response).toJson(QJsonDocument::Compact));
+    socket->write("\n");
+    socket->flush();
+}

--- a/src/qvipcserver.h
+++ b/src/qvipcserver.h
@@ -1,0 +1,43 @@
+#ifndef QVIPCSERVER_H
+#define QVIPCSERVER_H
+
+#include <QJsonObject>
+#include <QLocalServer>
+#include <QObject>
+#include <QStringList>
+
+class QVApplication;
+class QLocalSocket;
+
+class QVIPCServer : public QObject
+{
+    Q_OBJECT
+
+public:
+    struct ServerOption
+    {
+        bool enabled = false;
+        QString serverName;
+    };
+
+    explicit QVIPCServer(QVApplication *app);
+
+    bool listen(const QString &serverName);
+    QString serverName() const;
+
+    static QString defaultServerName();
+    static ServerOption extractServerOption(QStringList *arguments);
+    static QJsonObject handleMessage(const QJsonObject &message, const QString &currentFilePath);
+
+private slots:
+    void acceptConnections();
+
+private:
+    void handleSocketData(QLocalSocket *socket);
+    void sendResponse(QLocalSocket *socket, const QJsonObject &response);
+
+    QVApplication *application;
+    QLocalServer localServer;
+};
+
+#endif // QVIPCSERVER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_SOURCES
     ../src/qvwelcomedialog.cpp
     ../src/qvinfodialog.cpp
     ../src/qvimagecore.cpp
+    ../src/qvipcserver.cpp
     ../src/qvshortcutdialog.cpp
     ../src/actionmanager.cpp
     ../src/settingsmanager.cpp

--- a/tests/tst_actionmanagertests.cpp
+++ b/tests/tst_actionmanagertests.cpp
@@ -1,6 +1,7 @@
 #include <QtTest>
 
 #include "qvapplication.h"
+#include "qvipcserver.h"
 
 class ActionManagerTests : public QObject
 {
@@ -12,6 +13,10 @@ public:
 
 private slots:
     void testClonedActionsUntracked();
+    void testIpcServerOptionDisabledByDefault();
+    void testIpcServerOptionUsesDefaultSocket();
+    void testIpcServerOptionAcceptsExplicitSocket();
+    void testIpcCurrentFilePathResponse();
 };
 
 ActionManagerTests::ActionManagerTests() { }
@@ -39,6 +44,55 @@ void ActionManagerTests::testClonedActionsUntracked()
     QCOMPARE(qvApp->getActionManager().getAllInstancesOfAction("fullscreen").length(),
              fullscreenCount);
     QCOMPARE(qvApp->getActionManager().getAllInstancesOfAction("open").length(), openCount);
+}
+
+void ActionManagerTests::testIpcServerOptionDisabledByDefault()
+{
+    QStringList arguments = { "qview", "image.jpg" };
+    const auto option = QVIPCServer::extractServerOption(&arguments);
+
+    QVERIFY(!option.enabled);
+    QVERIFY(option.serverName.isEmpty());
+    QCOMPARE(arguments, QStringList({ "qview", "image.jpg" }));
+}
+
+void ActionManagerTests::testIpcServerOptionUsesDefaultSocket()
+{
+    QStringList arguments = { "qview", "image.jpg", "--ipc-server" };
+    const auto option = QVIPCServer::extractServerOption(&arguments);
+
+    QVERIFY(option.enabled);
+    QCOMPARE(option.serverName, QVIPCServer::defaultServerName());
+    QCOMPARE(arguments, QStringList({ "qview", "image.jpg" }));
+}
+
+void ActionManagerTests::testIpcServerOptionAcceptsExplicitSocket()
+{
+    QStringList arguments = { "qview", "--ipc-server=/tmp/qview-test.sock", "image.jpg" };
+    const auto option = QVIPCServer::extractServerOption(&arguments);
+
+    QVERIFY(option.enabled);
+    QCOMPARE(option.serverName, QString("/tmp/qview-test.sock"));
+    QCOMPARE(arguments, QStringList({ "qview", "image.jpg" }));
+}
+
+void ActionManagerTests::testIpcCurrentFilePathResponse()
+{
+    const QJsonObject request = { { QStringLiteral("method"), QStringLiteral("currentFilePath") } };
+
+    QCOMPARE(QVIPCServer::handleMessage(request, "/tmp/image.jpg").value("ok").toBool(), true);
+    QCOMPARE(QVIPCServer::handleMessage(request, "/tmp/image.jpg").value("path").toString(),
+             QString("/tmp/image.jpg"));
+
+    const QJsonObject noFileResponse = QVIPCServer::handleMessage(request, QString());
+    QCOMPARE(noFileResponse.value("ok").toBool(), false);
+    QCOMPARE(noFileResponse.value("error").toString(), QString("no_current_file"));
+
+    const QJsonObject unknownResponse =
+            QVIPCServer::handleMessage({ { QStringLiteral("method"), QStringLiteral("missing") } },
+                                        "/tmp/image.jpg");
+    QCOMPARE(unknownResponse.value("ok").toBool(), false);
+    QCOMPARE(unknownResponse.value("error").toString(), QString("unknown_method"));
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR has been planned and generated by Codex (GPT 5.5).

It is the first step towards making qView scriptable.

## Summary
- add an opt-in --ipc-server local JSON socket
- support a currentFilePath IPC method that returns the active image path
- document the newline-delimited JSON protocol and a socat-based Zsh helper

## Testing
- cmake -S . -B build -G Ninja -DBUILD_TESTS=ON
- cmake --build build
- ctest --test-dir build --output-on-failure
- manual socat query against build/qView.app returned the absolute path for resources/checkmark.png
