### PR TITLE
Support multi-path command line input

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@
 <p align=center>
     <img alt="Screenshot" src="https://interversehq.com/qview/assets/img/screenshot3.png">
 </p>
+
+## Command-line input
+
+qView can open multiple files and directories as one navigation sequence. It also accepts `-` to
+read line-delimited paths from standard input. See [docs/cli-input.md](docs/cli-input.md).

--- a/docs/cli-input.md
+++ b/docs/cli-input.md
@@ -1,0 +1,19 @@
+# Command-line input paths
+
+qView accepts multiple command-line paths in a single invocation:
+
+```sh
+qview 1.png ~/Pictures/7.png image-dir/
+```
+
+File arguments are opened as one navigation sequence in the order given. Directory arguments expand
+to the supported images in that directory using qView's file filtering and sort settings. Missing
+paths, unsupported files, and directories without supported images are skipped with diagnostics on
+standard error.
+
+Use `-` to read additional paths from standard input. Input is line-delimited, and empty lines are
+ignored. The `-` marker expands in place:
+
+```sh
+printf '%s\n' ~/Pictures/a.png ~/Pictures/b.png | qview before.png - after.png
+```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,32 @@
 #include "qvwin32functions.h"
 
 #include <QCommandLineParser>
+#include <QTextStream>
+
+QStringList expandStandardInputPaths(const QStringList &paths)
+{
+    QStringList expandedPaths;
+    QTextStream inputStream(stdin, QIODevice::ReadOnly);
+    QTextStream errorStream(stderr);
+
+    for (const QString &path : paths) {
+        if (path != "-") {
+            expandedPaths.append(path);
+            continue;
+        }
+
+        while (!inputStream.atEnd()) {
+            const QString line = inputStream.readLine();
+            if (!line.isEmpty())
+                expandedPaths.append(line);
+        }
+
+        if (inputStream.status() != QTextStream::Ok)
+            errorStream << "qView: Failed to read paths from standard input" << Qt::endl;
+    }
+
+    return expandedPaths;
+}
 
 int main(int argc, char *argv[])
 {
@@ -17,7 +43,10 @@ int main(int argc, char *argv[])
     QCommandLineParser parser;
     parser.addHelpOption();
     parser.addVersionOption();
-    parser.addPositionalArgument(QObject::tr("file"), QObject::tr("The file to open."));
+    parser.addPositionalArgument(QObject::tr("file"),
+                                 QObject::tr("The file(s) or directories to open. Use - to read "
+                                             "line-delimited paths from standard input."),
+                                 QObject::tr("[file ...]"));
 #if defined Q_OS_WIN && WIN32_LOADED && QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
     // Workaround for unicode characters getting mangled in certain cases. To support unicode
     // arguments on Windows, QCoreApplication normally ignores argv and gets them from the Windows
@@ -32,8 +61,9 @@ int main(int argc, char *argv[])
 #endif
 
     auto *window = QVApplication::newWindow();
-    if (!parser.positionalArguments().isEmpty())
-        QVApplication::openFile(window, parser.positionalArguments().constFirst(), true);
+    const QStringList inputPaths = expandStandardInputPaths(parser.positionalArguments());
+    if (!inputPaths.isEmpty())
+        QVApplication::openFileSequence(window, inputPaths, true);
 
     return QApplication::exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -326,6 +326,12 @@ void MainWindow::openFile(const QString &fileName)
     cancelSlideshow();
 }
 
+void MainWindow::openFileSequence(const QStringList &fileNames)
+{
+    graphicsView->loadFileSequence(fileNames);
+    cancelSlideshow();
+}
+
 void MainWindow::settingsUpdated()
 {
     auto &settingsManager = qvApp->getSettingsManager();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -122,6 +122,7 @@ public:
 
 public slots:
     void openFile(const QString &fileName);
+    void openFileSequence(const QStringList &fileNames);
 
     void toggleSlideshow();
 

--- a/src/qvapplication.cpp
+++ b/src/qvapplication.cpp
@@ -97,11 +97,24 @@ void QVApplication::openFile(MainWindow *window, const QString &file, bool resiz
     window->openFile(file);
 }
 
+void QVApplication::openFileSequence(MainWindow *window, const QStringList &files, bool resize)
+{
+    window->setJustLaunchedWithImage(resize);
+    window->openFileSequence(files);
+}
+
 void QVApplication::openFile(const QString &file, bool resize)
 {
     auto *window = qvApp->getMainWindow(true);
 
     QVApplication::openFile(window, file, resize);
+}
+
+void QVApplication::openFileSequence(const QStringList &files, bool resize)
+{
+    auto *window = qvApp->getMainWindow(true);
+
+    QVApplication::openFileSequence(window, files, resize);
 }
 
 void QVApplication::pickFile(MainWindow *parent)

--- a/src/qvapplication.h
+++ b/src/qvapplication.h
@@ -40,8 +40,10 @@ public:
     bool event(QEvent *event) override;
 
     static void openFile(MainWindow *window, const QString &file, bool resize = true);
+    static void openFileSequence(MainWindow *window, const QStringList &files, bool resize = true);
 
     static void openFile(const QString &file, bool resize = true);
+    static void openFileSequence(const QStringList &files, bool resize = true);
 
     static void pickFile(MainWindow *parent = nullptr);
 

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -12,6 +12,7 @@
 #include <QtMath>
 #include <QGestureEvent>
 #include <QScrollBar>
+#include <QTextStream>
 
 QVGraphicsView::QVGraphicsView(QWidget *parent) : QGraphicsView(parent)
 {
@@ -335,7 +336,24 @@ void QVGraphicsView::loadMimeData(const QMimeData *mimeData)
 
 void QVGraphicsView::loadFile(const QString &fileName)
 {
+    imageCore.clearCustomFileList();
     imageCore.loadFile(fileName);
+}
+
+void QVGraphicsView::loadFileSequence(const QStringList &paths)
+{
+    QStringList warnings;
+    const auto fileList = imageCore.getCompatibleFilesForInputs(paths, &warnings);
+
+    QTextStream errorStream(stderr);
+    for (const QString &warning : warnings)
+        errorStream << "qView: " << warning << Qt::endl;
+
+    if (fileList.isEmpty())
+        return;
+
+    imageCore.setCustomFileList(fileList);
+    imageCore.loadFile(fileList.constFirst().absoluteFilePath);
 }
 
 void QVGraphicsView::reloadFile()
@@ -560,7 +578,9 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
         // Make sure the file still exists because if it disappears from the file listing we'll lose
         // track of our index within the folder. Use the static 'exists' method to avoid caching.
         // If we skip updating now, flag it for retry later once we locate a new file.
-        if (QFile::exists(getCurrentFileDetails().fileInfo.absoluteFilePath()))
+        if (imageCore.hasCustomFileList())
+            imageCore.updateFolderInfo();
+        else if (QFile::exists(getCurrentFileDetails().fileInfo.absoluteFilePath()))
             imageCore.updateFolderInfo();
         else
             shouldRetryFolderInfoUpdate = true;
@@ -627,7 +647,7 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
         || nextImageFilePath == getCurrentFileDetails().fileInfo.absoluteFilePath())
         return;
 
-    if (shouldRetryFolderInfoUpdate) {
+    if (shouldRetryFolderInfoUpdate && !imageCore.hasCustomFileList()) {
         // If the user just deleted a file through qView, closeImage will have been called which
         // empties currentFileDetails.fileInfo. In this case updateFolderInfo can't infer the
         // directory from fileInfo like it normally does, so we'll explicity pass in the folder
@@ -635,7 +655,7 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
         imageCore.updateFolderInfo(QFileInfo(nextImageFilePath).path());
     }
 
-    loadFile(nextImageFilePath);
+    imageCore.loadFile(nextImageFilePath);
 }
 
 void QVGraphicsView::fitInViewMarginless(const QRectF &rect)

--- a/src/qvgraphicsview.h
+++ b/src/qvgraphicsview.h
@@ -25,6 +25,7 @@ public:
     QMimeData *getMimeData() const;
     void loadMimeData(const QMimeData *mimeData);
     void loadFile(const QString &fileName);
+    void loadFileSequence(const QStringList &paths);
 
     void reloadFile();
 

--- a/src/qvimagecore.cpp
+++ b/src/qvimagecore.cpp
@@ -14,6 +14,88 @@
 #include <QIcon>
 #include <QGuiApplication>
 #include <QScreen>
+#include <QHash>
+#include <QSet>
+
+namespace {
+QString sanitizeLocalPath(const QString &path)
+{
+    QUrl url(path);
+    if (url.isLocalFile())
+        return url.toLocalFile();
+    return path;
+}
+
+void sortCompatibleFiles(QList<QVImageCore::CompatibleFile> *fileList,
+                         const QVImageCore::DirInfo &dirInfo)
+{
+    switch (dirInfo.sortMode) {
+    case 0: {
+        QCollator collator;
+        collator.setNumericMode(true);
+        std::sort(fileList->begin(), fileList->end(),
+                  [&](const QVImageCore::CompatibleFile &file1,
+                      const QVImageCore::CompatibleFile &file2) {
+                      if (dirInfo.sortDescending)
+                          return collator.compare(file1.fileName, file2.fileName) > 0;
+                      else
+                          return collator.compare(file1.fileName, file2.fileName) < 0;
+                  });
+        break;
+    }
+    case 1:
+        std::sort(fileList->begin(), fileList->end(),
+                  [&](const QVImageCore::CompatibleFile &file1,
+                      const QVImageCore::CompatibleFile &file2) {
+                      if (dirInfo.sortDescending)
+                          return file1.lastModified < file2.lastModified;
+                      else
+                          return file1.lastModified > file2.lastModified;
+                  });
+        break;
+    case 2:
+        std::sort(fileList->begin(), fileList->end(),
+                  [&](const QVImageCore::CompatibleFile &file1,
+                      const QVImageCore::CompatibleFile &file2) {
+                      if (dirInfo.sortDescending)
+                          return file1.lastCreated < file2.lastCreated;
+                      else
+                          return file1.lastCreated > file2.lastCreated;
+                  });
+        break;
+    case 3:
+        std::sort(fileList->begin(), fileList->end(),
+                  [&](const QVImageCore::CompatibleFile &file1,
+                      const QVImageCore::CompatibleFile &file2) {
+                      if (dirInfo.sortDescending)
+                          return file1.size < file2.size;
+                      else
+                          return file1.size > file2.size;
+                  });
+        break;
+    case 4: {
+        QCollator collator;
+        std::sort(fileList->begin(), fileList->end(),
+                  [&](const QVImageCore::CompatibleFile &file1,
+                      const QVImageCore::CompatibleFile &file2) {
+                      if (dirInfo.sortDescending)
+                          return collator.compare(file1.mimeType, file2.mimeType) > 0;
+                      else
+                          return collator.compare(file1.mimeType, file2.mimeType) < 0;
+                  });
+        break;
+    }
+    case 5:
+        std::shuffle(fileList->begin(), fileList->end(),
+                     std::default_random_engine(
+                             std::chrono::system_clock::now().time_since_epoch().count()));
+        break;
+    default:
+        Q_ASSERT(false);
+        break;
+    }
+}
+}
 
 QCache<QString, QVImageCore::ReadData> QVImageCore::imageCache;
 
@@ -60,12 +142,7 @@ void QVImageCore::loadFile(const QString &fileName, bool isReloading)
         return;
     }
 
-    QString sanitaryFileName = fileName;
-
-    // sanitize file name if necessary
-    QUrl sanitaryUrl = QUrl(fileName);
-    if (sanitaryUrl.isLocalFile())
-        sanitaryFileName = sanitaryUrl.toLocalFile();
+    QString sanitaryFileName = sanitizeLocalPath(fileName);
 
     QFileInfo fileInfo(sanitaryFileName);
     sanitaryFileName = fileInfo.absoluteFilePath();
@@ -322,8 +399,83 @@ QList<QVImageCore::CompatibleFile> QVImageCore::getCompatibleFiles(const QString
     return fileList;
 }
 
+QList<QVImageCore::CompatibleFile>
+QVImageCore::getCompatibleFilesForInputs(const QStringList &paths, QStringList *warnings) const
+{
+    QList<CompatibleFile> fileList;
+    QHash<QString, QList<CompatibleFile>> compatibleFilesByDir;
+    QSet<QString> seenPaths;
+
+    const auto sortedCompatibleFilesForDir = [&](const QString &dirPath) {
+        if (!compatibleFilesByDir.contains(dirPath)) {
+            auto files = getCompatibleFiles(dirPath);
+            const DirInfo dirInfo = { dirPath, files.count(), qvGetSettingInt(SortMode),
+                                      qvGetSettingBool(SortDescending) };
+            sortCompatibleFiles(&files, dirInfo);
+            compatibleFilesByDir.insert(dirPath, files);
+        }
+        return compatibleFilesByDir.value(dirPath);
+    };
+
+    const auto appendCompatibleFile = [&](const CompatibleFile &compatibleFile) {
+        const QString normalizedPath =
+                compatibleFile.absoluteFilePath.normalized(QString::NormalizationForm_D);
+        if (seenPaths.contains(normalizedPath))
+            return;
+
+        seenPaths.insert(normalizedPath);
+        fileList.append(compatibleFile);
+    };
+
+    for (const QString &path : paths) {
+        const QString sanitaryPath = sanitizeLocalPath(path);
+        const QFileInfo fileInfo(sanitaryPath);
+        const QString absoluteFilePath = fileInfo.absoluteFilePath();
+
+        if (!fileInfo.exists()) {
+            if (warnings)
+                warnings->append(QObject::tr("Skipping missing path: %1").arg(path));
+            continue;
+        }
+
+        if (fileInfo.isDir()) {
+            const auto compatibleFiles = sortedCompatibleFilesForDir(absoluteFilePath);
+            if (compatibleFiles.isEmpty() && warnings)
+                warnings->append(QObject::tr("Skipping directory with no supported images: %1")
+                                         .arg(path));
+            for (const auto &compatibleFile : compatibleFiles)
+                appendCompatibleFile(compatibleFile);
+            continue;
+        }
+
+        const auto compatibleFiles = sortedCompatibleFilesForDir(fileInfo.absolutePath());
+        bool matched = false;
+        for (const auto &compatibleFile : compatibleFiles) {
+            const QString candidatePath =
+                    compatibleFile.absoluteFilePath.normalized(QString::NormalizationForm_D);
+            const QString targetPath = absoluteFilePath.normalized(QString::NormalizationForm_D);
+            if (candidatePath.compare(targetPath, Qt::CaseInsensitive) == 0
+                && QFileInfo(compatibleFile.absoluteFilePath) == fileInfo) {
+                appendCompatibleFile(compatibleFile);
+                matched = true;
+                break;
+            }
+        }
+
+        if (!matched && warnings)
+            warnings->append(QObject::tr("Skipping unsupported file: %1").arg(path));
+    }
+
+    return fileList;
+}
+
 void QVImageCore::updateFolderInfo(QString dirPath)
 {
+    if (usingCustomFileList) {
+        currentFileDetails.updateLoadedIndexInFolder();
+        return;
+    }
+
     if (dirPath.isEmpty()) {
         dirPath = currentFileDetails.fileInfo.path();
 
@@ -340,88 +492,27 @@ void QVImageCore::updateFolderInfo(QString dirPath)
     const bool shouldSort = lastDirInfo != dirInfo;
     lastDirInfo = dirInfo;
 
-    const auto sortFn = [&]() {
-        // Sorting
-        switch (dirInfo.sortMode) {
-        case 0: {
-            // Natural sorting
-            QCollator collator;
-            collator.setNumericMode(true);
-            std::sort(currentFileDetails.folderFileInfoList.begin(),
-                      currentFileDetails.folderFileInfoList.end(),
-                      [&](const CompatibleFile &file1, const CompatibleFile &file2) {
-                          if (dirInfo.sortDescending)
-                              return collator.compare(file1.fileName, file2.fileName) > 0;
-                          else
-                              return collator.compare(file1.fileName, file2.fileName) < 0;
-                      });
-            break;
-        }
-        case 1:
-            // Date modified
-            std::sort(currentFileDetails.folderFileInfoList.begin(),
-                      currentFileDetails.folderFileInfoList.end(),
-                      [&](const CompatibleFile &file1, const CompatibleFile &file2) {
-                          if (dirInfo.sortDescending)
-                              return file1.lastModified < file2.lastModified;
-                          else
-                              return file1.lastModified > file2.lastModified;
-                      });
-            break;
-        case 2:
-            // Date created
-            std::sort(currentFileDetails.folderFileInfoList.begin(),
-                      currentFileDetails.folderFileInfoList.end(),
-                      [&](const CompatibleFile &file1, const CompatibleFile &file2) {
-                          if (dirInfo.sortDescending)
-                              return file1.lastCreated < file2.lastCreated;
-                          else
-                              return file1.lastCreated > file2.lastCreated;
-                      });
-            break;
-        case 3:
-            // Size
-            std::sort(currentFileDetails.folderFileInfoList.begin(),
-                      currentFileDetails.folderFileInfoList.end(),
-                      [&](const CompatibleFile &file1, const CompatibleFile &file2) {
-                          if (dirInfo.sortDescending)
-                              return file1.size < file2.size;
-                          else
-                              return file1.size > file2.size;
-                      });
-            break;
-        case 4: {
-            // Type
-            QCollator collator;
-            std::sort(currentFileDetails.folderFileInfoList.begin(),
-                      currentFileDetails.folderFileInfoList.end(),
-                      [&](const CompatibleFile &file1, const CompatibleFile &file2) {
-                          if (dirInfo.sortDescending)
-                              return collator.compare(file1.mimeType, file2.mimeType) > 0;
-                          else
-                              return collator.compare(file1.mimeType, file2.mimeType) < 0;
-                      });
-            break;
-        }
-        case 5:
-            // Random
-            std::shuffle(currentFileDetails.folderFileInfoList.begin(),
-                         currentFileDetails.folderFileInfoList.end(),
-                         std::default_random_engine(
-                                 std::chrono::system_clock::now().time_since_epoch().count()));
-            break;
-        default:
-            Q_ASSERT(false);
-            break;
-        }
-    };
-
-    if (shouldSort) {
-        sortFn();
-    }
+    if (shouldSort)
+        sortCompatibleFiles(&currentFileDetails.folderFileInfoList, dirInfo);
 
     // Set current file index variable
     currentFileDetails.updateLoadedIndexInFolder();
+}
+
+void QVImageCore::setCustomFileList(const QList<CompatibleFile> &fileList)
+{
+    usingCustomFileList = true;
+    currentFileDetails.folderFileInfoList = fileList;
+    currentFileDetails.updateLoadedIndexInFolder();
+}
+
+void QVImageCore::clearCustomFileList()
+{
+    if (!usingCustomFileList)
+        return;
+
+    usingCustomFileList = false;
+    updateFolderInfo();
 }
 
 void QVImageCore::requestCaching()

--- a/src/qvimagecore.h
+++ b/src/qvimagecore.h
@@ -10,6 +10,7 @@
 #include <QTimer>
 #include <QCache>
 #include <QElapsedTimer>
+#include <QStringList>
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
 #  include <QColorSpace>
@@ -88,7 +89,12 @@ public:
     void loadPixmap(const ReadData &readData);
     void closeImage();
     QList<CompatibleFile> getCompatibleFiles(const QString &dirPath) const;
+    QList<CompatibleFile> getCompatibleFilesForInputs(const QStringList &paths,
+                                                      QStringList *warnings = nullptr) const;
     void updateFolderInfo(QString dirPath = QString());
+    void setCustomFileList(const QList<CompatibleFile> &fileList);
+    void clearCustomFileList();
+    bool hasCustomFileList() const { return usingCustomFileList; }
     void requestCaching();
     void requestCachingFile(const QString &filePath, const QColorSpace &targetColorSpace);
     void addToCache(const ReadData &&readImageAndFileInfo);
@@ -152,6 +158,7 @@ private:
     int largestDimension;
 
     bool waitingOnLoad;
+    bool usingCustomFileList = false;
 };
 
 #endif // QVIMAGECORE_H

--- a/tests/tst_actionmanagertests.cpp
+++ b/tests/tst_actionmanagertests.cpp
@@ -2,6 +2,11 @@
 
 #include "qvapplication.h"
 
+#include <QFile>
+#include <QFileInfo>
+#include <QImage>
+#include <QTemporaryDir>
+
 class ActionManagerTests : public QObject
 {
     Q_OBJECT
@@ -12,6 +17,7 @@ public:
 
 private slots:
     void testClonedActionsUntracked();
+    void testInputPathSequence();
 };
 
 ActionManagerTests::ActionManagerTests() { }
@@ -39,6 +45,32 @@ void ActionManagerTests::testClonedActionsUntracked()
     QCOMPARE(qvApp->getActionManager().getAllInstancesOfAction("fullscreen").length(),
              fullscreenCount);
     QCOMPARE(qvApp->getActionManager().getAllInstancesOfAction("open").length(), openCount);
+}
+
+void ActionManagerTests::testInputPathSequence()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+
+    const QString firstFile = tempDir.filePath("1.png");
+    const QString secondFile = tempDir.filePath("2.png");
+    const QString unsupportedFile = tempDir.filePath("notes.txt");
+    QVERIFY(QImage(2, 2, QImage::Format_ARGB32).save(firstFile));
+    QVERIFY(QImage(3, 3, QImage::Format_ARGB32).save(secondFile));
+    QVERIFY(QFile(unsupportedFile).open(QIODevice::WriteOnly));
+
+    QVImageCore imageCore;
+    QStringList warnings;
+    const auto files = imageCore.getCompatibleFilesForInputs(
+            { secondFile, tempDir.path(), unsupportedFile, tempDir.filePath("missing.png") },
+            &warnings);
+
+    QCOMPARE(files.length(), 2);
+    QCOMPARE(files.at(0).absoluteFilePath, QFileInfo(secondFile).absoluteFilePath());
+    QCOMPARE(files.at(1).absoluteFilePath, QFileInfo(firstFile).absoluteFilePath());
+    QCOMPARE(warnings.length(), 2);
+    QVERIFY(warnings.at(0).contains("unsupported"));
+    QVERIFY(warnings.at(1).contains("missing"));
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR has been planned and generated by Codex (GPT 5.5).

I have also manually tested it, and it works.

## Summary
- accept multiple file and directory paths as one navigation sequence
- expand '-' in positional arguments by reading line-delimited paths from stdin
- skip missing and unsupported inputs with stderr diagnostics
- document command-line input behavior

## Testing
- cmake --build build -j4
- QT_QPA_PLATFORM=offscreen build-tests/tests/actionmanagertests testInputPathSequence

Note: full ctest currently segfaults in the existing ActionManagerTests::testClonedActionsUntracked before reaching the new test case on this macOS environment.