### PR TITLE
Fix file navigation wrapping past missing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@
 <p align=center>
     <img alt="Screenshot" src="https://interversehq.com/qview/assets/img/screenshot3.png">
 </p>
+
+## Documentation
+
+Default file navigation shortcuts are documented in
+[docs/keybindings.md](docs/keybindings.md).

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,0 +1,10 @@
+# Keybindings
+
+## File navigation
+
+| Action | Default key |
+| --- | --- |
+| First File | `Home` |
+| Previous File | `Left` |
+| Next File | `Right` |
+| Last File | `End` |

--- a/src/qvgraphicsview.cpp
+++ b/src/qvgraphicsview.cpp
@@ -613,12 +613,29 @@ void QVGraphicsView::goToFile(const GoToFileMode &mode, int index)
     }
 
     if (searchDirection != 0) {
-        while (searchDirection == 1 && newIndex < fileList.size() - 1
-               && !QFile::exists(fileList.value(newIndex).absoluteFilePath))
-            newIndex++;
-        while (searchDirection == -1 && newIndex > 0
-               && !QFile::exists(fileList.value(newIndex).absoluteFilePath))
-            newIndex--;
+        const bool canWrap = qvGetSettingBool(LoopFoldersEnabled)
+                && (mode == GoToFileMode::previous || mode == GoToFileMode::next);
+        bool foundExistingFile = false;
+        for (int checkedFiles = 0; checkedFiles < fileList.size(); checkedFiles++) {
+            if (newIndex < 0 || newIndex >= fileList.size())
+                break;
+
+            if (QFile::exists(fileList.value(newIndex).absoluteFilePath)) {
+                foundExistingFile = true;
+                break;
+            }
+
+            newIndex += searchDirection;
+            if (canWrap) {
+                if (newIndex >= fileList.size())
+                    newIndex = 0;
+                else if (newIndex < 0)
+                    newIndex = fileList.size() - 1;
+            }
+        }
+
+        if (!foundExistingFile)
+            return;
     }
 
     const QString nextImageFilePath = fileList.value(newIndex).absoluteFilePath;

--- a/tests/tst_actionmanagertests.cpp
+++ b/tests/tst_actionmanagertests.cpp
@@ -2,6 +2,12 @@
 
 #include "qvapplication.h"
 
+#include <QFile>
+#include <QFileInfo>
+#include <QImage>
+#include <QSettings>
+#include <QTemporaryDir>
+
 class ActionManagerTests : public QObject
 {
     Q_OBJECT
@@ -12,6 +18,8 @@ public:
 
 private slots:
     void testClonedActionsUntracked();
+    void testNextFileWrapsPastMissingFiles();
+    void testPreviousFileWrapsPastMissingFiles();
 };
 
 ActionManagerTests::ActionManagerTests() { }
@@ -41,8 +49,63 @@ void ActionManagerTests::testClonedActionsUntracked()
     QCOMPARE(qvApp->getActionManager().getAllInstancesOfAction("open").length(), openCount);
 }
 
+void ActionManagerTests::testNextFileWrapsPastMissingFiles()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+
+    const QString firstFile = tempDir.filePath("1.png");
+    const QString currentFile = tempDir.filePath("2.png");
+    const QString missingNextFile = tempDir.filePath("3.png");
+    QVERIFY(QImage(2, 2, QImage::Format_ARGB32).save(firstFile));
+    QVERIFY(QImage(3, 3, QImage::Format_ARGB32).save(currentFile));
+    QVERIFY(QImage(4, 4, QImage::Format_ARGB32).save(missingNextFile));
+
+    QWidget parent;
+    QVGraphicsView view(&parent);
+    view.loadFile(currentFile);
+    QTRY_COMPARE(view.getCurrentFileDetails().fileInfo.absoluteFilePath(),
+                 QFileInfo(currentFile).absoluteFilePath());
+
+    QVERIFY(QFile::remove(missingNextFile));
+    view.goToFile(QVGraphicsView::GoToFileMode::next);
+    QTRY_COMPARE(view.getCurrentFileDetails().fileInfo.absoluteFilePath(),
+                 QFileInfo(firstFile).absoluteFilePath());
+}
+
+void ActionManagerTests::testPreviousFileWrapsPastMissingFiles()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+
+    const QString missingPreviousFile = tempDir.filePath("1.png");
+    const QString currentFile = tempDir.filePath("2.png");
+    const QString lastFile = tempDir.filePath("3.png");
+    QVERIFY(QImage(2, 2, QImage::Format_ARGB32).save(missingPreviousFile));
+    QVERIFY(QImage(3, 3, QImage::Format_ARGB32).save(currentFile));
+    QVERIFY(QImage(4, 4, QImage::Format_ARGB32).save(lastFile));
+
+    QWidget parent;
+    QVGraphicsView view(&parent);
+    view.loadFile(currentFile);
+    QTRY_COMPARE(view.getCurrentFileDetails().fileInfo.absoluteFilePath(),
+                 QFileInfo(currentFile).absoluteFilePath());
+
+    QVERIFY(QFile::remove(missingPreviousFile));
+    view.goToFile(QVGraphicsView::GoToFileMode::previous);
+    QTRY_COMPARE(view.getCurrentFileDetails().fileInfo.absoluteFilePath(),
+                 QFileInfo(lastFile).absoluteFilePath());
+}
+
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setOrganizationName("qViewTests");
+    QCoreApplication::setApplicationName("qViewTests");
+    QSettings settings;
+    settings.beginGroup("options");
+    settings.setValue("colorspaceconversion", 0);
+    settings.endGroup();
+
     QVApplication app(argc, argv);
     ActionManagerTests actionManagerTests;
     return QTest::qExec(&actionManagerTests, argc, argv);


### PR DESCRIPTION
## Summary
- make Next/Previous File continue scanning when wrapping past missing files
- document default file navigation keybindings
- add regression tests for missing-file wrap navigation

## Tests
- cmake -B build -DBUILD_TESTS=ON
- cmake --build build --parallel
- /usr/bin/env QT_QPA_PLATFORM=offscreen build/tests/actionmanagertests testNextFileWrapsPastMissingFiles testPreviousFileWrapsPastMissingFiles

Note: full ctest is blocked in this headless session by the pre-existing testClonedActionsUntracked window test, which aborts/segfaults without a normal screen.